### PR TITLE
Improve circuit builder API

### DIFF
--- a/examples/supermuc_sweep/main.rs
+++ b/examples/supermuc_sweep/main.rs
@@ -66,7 +66,7 @@ fn read_circuit(file: &str) -> Tensor {
     let source = fs::read_to_string(file).unwrap();
     let circuit = create_tensornetwork(source);
     let qubits = circuit.num_qubits();
-    let tensor = circuit.into_amplitude_network(&"0".repeat(qubits));
+    let (tensor, _) = circuit.into_amplitude_network(&"0".repeat(qubits));
 
     last_values.replace((file.into(), tensor.clone()));
     tensor

--- a/examples/supermuc_sweep/main.rs
+++ b/examples/supermuc_sweep/main.rs
@@ -13,7 +13,6 @@ use itertools::{iproduct, Itertools};
 use log::info;
 use mpi::topology::SimpleCommunicator;
 use mpi::traits::{Communicator, CommunicatorCollectives};
-use num_complex::Complex64;
 use protocol::Protocol;
 use rand::distributions::Standard;
 use rand::rngs::StdRng;
@@ -45,7 +44,6 @@ use tnc::tensornetwork::contraction::contract_tensor_network;
 use tnc::tensornetwork::partitioning::find_partitioning;
 use tnc::tensornetwork::partitioning::partition_config::PartitioningStrategy;
 use tnc::tensornetwork::tensor::Tensor;
-use tnc::tensornetwork::tensordata::TensorData;
 use tnc::types::ContractionIndex;
 use utils::{hash_str, parse_range_list, setup_logging_mpi};
 
@@ -66,18 +64,9 @@ fn read_circuit(file: &str) -> Tensor {
         }
     }
     let source = fs::read_to_string(file).unwrap();
-    let (mut tensor, open_legs) = create_tensornetwork(source);
-
-    // Add bras to each open leg
-    for leg in open_legs {
-        let mut bra = Tensor::new_from_const(vec![leg], 2);
-        bra.set_tensor_data(TensorData::new_from_data(
-            &[2],
-            vec![Complex64::ONE, Complex64::ONE],
-            None,
-        ));
-        tensor.push_tensor(bra);
-    }
+    let circuit = create_tensornetwork(source);
+    let qubits = circuit.num_qubits();
+    let tensor = circuit.into_amplitude_network(&"0".repeat(qubits));
 
     last_values.replace((file.into(), tensor.clone()));
     tensor

--- a/src/builders/circuit_builder.rs
+++ b/src/builders/circuit_builder.rs
@@ -1,26 +1,81 @@
-use std::f64::consts::FRAC_1_SQRT_2;
+use std::marker::PhantomData;
 
 use itertools::Itertools;
 use num_complex::Complex64;
-use rand::Rng;
-use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-    builders::tensorgeneration::random_sparse_tensor_data_with_rng,
     tensornetwork::{tensor::Tensor, tensordata::TensorData},
     types::EdgeIndex,
 };
 
+/// A quantum register, i.e., an array of qubits. Similar to the Qiskit / QASM
+/// idea, quantum registers group qubits (for instance, one qreg for ancillas), and
+/// a circuit can act on multiple qregs.
+#[derive(Debug)]
+pub struct QuantumRegister<'a> {
+    base: usize,
+    size: usize,
+    phantom: PhantomData<&'a Circuit>,
+}
+
+impl QuantumRegister<'_> {
+    /// Creates a new quantum register without any associated circuit. This is mainly
+    /// for testing.
+    #[cfg(test)]
+    pub(crate) fn new(size: usize) -> Self {
+        QuantumRegister {
+            base: 0,
+            size,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Returns the qubit at a given index.
+    pub fn qubit(&self, index: usize) -> Qubit {
+        assert!(index < self.size);
+        Qubit {
+            index: self.base + index,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Returns an iterator over all qubits in this register.
+    pub fn qubits(&self) -> impl Iterator<Item = Qubit> {
+        (self.base..self.base + self.size).map(|i| Qubit {
+            index: i,
+            phantom: PhantomData,
+        })
+    }
+
+    /// Returns the size of the register.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.size
+    }
+
+    /// Returns whether this register is empty, i.e., doesn't contain any qubits.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+}
+
+/// A single qubit from a quantum register.
+pub struct Qubit<'a> {
+    index: usize,
+    phantom: PhantomData<&'a Circuit>,
+}
+
 /// A quantum circuit builder that constructs a tensor network representing a quantum
 /// circuit.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Circuit {
-    /// Maps qubit indices to the last open edge on that qubit.
-    open_edges: FxHashMap<usize, EdgeIndex>,
+    /// The last open edges on each qubit.
+    open_edges: Vec<EdgeIndex>,
     /// The next edge to be used.
     next_edge: usize,
-    /// The tensor network representing the circuit.
-    tensor_network: Tensor,
+    /// The tensors representing the circuit.
+    tensors: Vec<Tensor>,
 }
 
 impl Circuit {
@@ -34,150 +89,85 @@ impl Circuit {
         TensorData::new_from_data(&[2], vec![Complex64::ZERO, Complex64::ONE], None)
     }
 
-    /// The |+> state.
-    fn ketplus() -> TensorData {
-        TensorData::new_from_data(
-            &[2],
-            vec![
-                Complex64::new(FRAC_1_SQRT_2, 0.0),
-                Complex64::new(FRAC_1_SQRT_2, 0.0),
-            ],
-            None,
-        )
+    /// Creates a new edge id.
+    fn new_edge(&mut self) -> usize {
+        let edge = self.next_edge;
+        self.next_edge += 1;
+        edge
     }
 
-    /// The |-> state.
-    fn ketminus() -> TensorData {
-        TensorData::new_from_data(
-            &[2],
-            vec![
-                Complex64::new(FRAC_1_SQRT_2, 0.0),
-                Complex64::new(-FRAC_1_SQRT_2, 0.0),
-            ],
-            None,
-        )
+    /// Returns the total number of qubits allocated in this circuit.
+    #[inline]
+    pub fn num_qubits(&self) -> usize {
+        self.open_edges.len()
     }
 
-    /// Initializes a circuit with qubits in the |0> state.
-    pub fn initialize_ket0(qubits: usize) -> Self {
-        Self::initialize(qubits, |_| Self::ket0())
-    }
+    /// Allocates a new quantum register. The qubits are initialized in the |0>
+    /// state.
+    pub fn allocate_register<'a>(&mut self, size: usize) -> QuantumRegister<'a> {
+        let previous_qubits = self.num_qubits();
 
-    /// Initializes a circuit given a bitstring containing `0`, `1`, `+`, or `-`.
-    pub fn initialize_bitstring(bitstring: &str) -> Self {
-        let qubits = bitstring.len();
-        Self::initialize(qubits, |i| match bitstring.chars().nth(i).unwrap() {
-            '0' => Self::ket0(),
-            '1' => Self::ket1(),
-            '+' => Self::ketplus(),
-            '-' => Self::ketminus(),
-            _ => panic!("Invalid bitstring"),
-        })
-    }
+        self.open_edges.reserve(size);
+        self.tensors.reserve(size);
+        for _ in 0..size {
+            let edge = self.new_edge();
+            self.open_edges.push(edge);
+            let mut ket0 = Tensor::new_from_const(vec![edge], 2);
+            ket0.set_tensor_data(Self::ket0());
+            self.tensors.push(ket0);
+        }
 
-    /// Initializes a circuit with qubits in a random product state.
-    pub fn initialize_random<R>(qubits: usize, rng: &mut R) -> Self
-    where
-        R: ?Sized + Rng,
-    {
-        Self::initialize(qubits, |_| {
-            random_sparse_tensor_data_with_rng(&[2], Some(1.0), rng)
-        })
-    }
-
-    /// Initializes a circuit with a function that returns a qubit state for each
-    /// qubit.
-    fn initialize<F>(qubits: usize, mut tensor_data_getter: F) -> Self
-    where
-        F: FnMut(usize) -> TensorData,
-    {
-        let open_edges = FxHashMap::from_iter((0..qubits).map(|i| (i, i)));
-        let next_edge = qubits;
-
-        let tensors = (0..qubits)
-            .map(|i| {
-                let mut tensor = Tensor::new_from_const(vec![i], 2);
-                tensor.set_tensor_data(tensor_data_getter(i));
-                tensor
-            })
-            .collect_vec();
-        let tensor_network = Tensor::new_composite(tensors);
-
-        Circuit {
-            open_edges,
-            next_edge,
-            tensor_network,
+        QuantumRegister {
+            base: previous_qubits,
+            size,
+            phantom: PhantomData,
         }
     }
 
     /// Appends a gate to the circuit on the specified qubits.
-    pub fn append_gate(&mut self, gate: TensorData, indices: &[usize]) {
-        assert_eq!(
-            FxHashSet::from_iter(indices).len(),
-            indices.len(),
-            "Qubit indices must be unique"
+    pub fn append_gate(&mut self, gate: TensorData, indices: &[Qubit]) {
+        assert!(
+            indices.iter().map(|q| q.index).all_unique(),
+            "Qubit arguments must be unique"
         );
 
-        let old_edges = indices.iter().map(|i| self.open_edges[i]).collect_vec();
-        let mut new_edges = (self.next_edge..self.next_edge + indices.len()).collect_vec();
+        // Get the old and new edges
+        let old_edges = indices.iter().map(|q| self.open_edges[q.index]);
+        let new_edges = (0..indices.len()).map(|e| e + self.next_edge);
+        let edges = new_edges.chain(old_edges.rev()).collect_vec();
         self.next_edge += indices.len();
 
         // Update the open edges
-        for (i, next_edge) in indices.iter().zip(&new_edges) {
-            self.open_edges.insert(*i, *next_edge);
+        for (q, next_edge) in indices.iter().zip(&edges[..indices.len()]) {
+            self.open_edges[q.index] = *next_edge;
         }
 
         // Create the new tensor
-        let mut edges = old_edges;
-        edges.append(&mut new_edges);
         let mut new_tensor = Tensor::new_from_const(edges, 2);
         new_tensor.set_tensor_data(gate);
 
-        // Push the new tensor to the tensor network
-        self.tensor_network.push_tensor(new_tensor);
+        // Push the new tensor to the tensors
+        self.tensors.push(new_tensor);
     }
 
-    /// Applies a layer of <0| to the end and returns the final tensor network.
-    pub fn finalize_ket0(self) -> Tensor {
-        self.finalize(|_| Self::ket0())
-    }
+    /// Converts the circuit to a tensor network that computes the amplitude for the
+    /// given bitstring.
+    pub fn into_amplitude_network(mut self, bitstring: &str) -> Tensor {
+        assert_eq!(bitstring.len(), self.num_qubits());
 
-    /// Applies a layer of qubit states given by a bitstring containing `0`, `1`, `+`
-    /// , or `-` and returns the final tensor network.
-    pub fn finalize_bitstring(self, bitstring: &str) -> Tensor {
-        self.finalize(|i| match bitstring.chars().nth(i).unwrap() {
-            '0' => Self::ket0(),
-            '1' => Self::ket1(),
-            '+' => Self::ketplus(),
-            '-' => Self::ketminus(),
-            _ => panic!("Invalid bitstring"),
-        })
-    }
-
-    /// Applies a random product state layer to the end and returns the final tensor network.
-    pub fn finalize_random<R>(self, rng: &mut R) -> Tensor
-    where
-        R: ?Sized + Rng,
-    {
-        self.finalize(|_| random_sparse_tensor_data_with_rng(&[2], Some(1.0), rng))
-    }
-
-    /// Applies a function that returns a qubit state for each qubit to the end and
-    /// returns the final tensor network.
-    fn finalize<F>(mut self, mut tensor_data_getter: F) -> Tensor
-    where
-        F: FnMut(usize) -> TensorData,
-    {
-        let qubits = self.open_edges.len();
-        let tensors = (0..qubits)
-            .map(|i| {
-                let mut tensor = Tensor::new_from_const(vec![self.open_edges[&i]], 2);
-                tensor.set_tensor_data(tensor_data_getter(i));
-                tensor
-            })
-            .collect_vec();
-        self.tensor_network.push_tensors(tensors);
-        self.tensor_network
+        self.tensors.reserve(bitstring.len());
+        for (c, e) in bitstring.chars().zip(self.open_edges) {
+            let bra = match c {
+                '0' => Self::ket0(),
+                '1' => Self::ket1(),
+                '*' => continue, // leave this edge open
+                _ => panic!("Only 0, 1 and * are allowed in bitstring"),
+            };
+            let mut tensor = Tensor::new_from_const(vec![e], 2);
+            tensor.set_tensor_data(bra);
+            self.tensors.push(tensor);
+        }
+        Tensor::new_composite(self.tensors)
     }
 }
 
@@ -203,11 +193,12 @@ mod tests {
     #[test]
     fn hadmards_expectation() {
         let qubits = 5;
-        let mut circuit = Circuit::initialize_ket0(qubits);
-        for i in 0..qubits {
-            circuit.append_gate(TensorData::Gate((String::from("h"), vec![], true)), &[i]);
+        let mut circuit = Circuit::default();
+        let qr = circuit.allocate_register(qubits);
+        for q in qr.qubits() {
+            circuit.append_gate(TensorData::Gate((String::from("h"), vec![], true)), &[q]);
         }
-        let tensor_network = circuit.finalize_ket0();
+        let tensor_network = circuit.into_amplitude_network("00000");
 
         let mut opt = Cotengrust::new(&tensor_network, OptMethod::Greedy);
         opt.optimize_path();
@@ -226,34 +217,13 @@ mod tests {
     }
 
     #[test]
-    fn superposition_expectation() {
-        let qubits = 3;
-        let circuit = Circuit::initialize_bitstring("+++");
-        let tensor_network = circuit.finalize_ket0();
-
-        let mut opt = Cotengrust::new(&tensor_network, OptMethod::Greedy);
-        opt.optimize_path();
-        let path = opt.get_best_replace_path();
-
-        let result = contract_tensor_network(tensor_network, &path);
-
-        let mut tn_ref = Tensor::default();
-        tn_ref.set_tensor_data(TensorData::new_from_data(
-            &[],
-            vec![Complex64::new(FRAC_1_SQRT_2.powi(qubits), 0.0)],
-            None,
-        ));
-
-        assert_approx_eq!(&Tensor, &result, &tn_ref);
-    }
-
-    #[test]
-    #[should_panic(expected = "Qubit indices must be unique")]
+    #[should_panic(expected = "Qubit arguments must be unique")]
     fn duplicate_qubit_arg() {
-        let mut circuit = Circuit::initialize_ket0(2);
+        let mut circuit = Circuit::default();
+        let qr = circuit.allocate_register(2);
         circuit.append_gate(
             TensorData::Gate((String::from("cx"), vec![], true)),
-            &[1, 1],
+            &[qr.qubit(1), qr.qubit(1)],
         );
     }
 }

--- a/src/builders/circuit_builder.rs
+++ b/src/builders/circuit_builder.rs
@@ -32,7 +32,7 @@ impl QuantumRegister<'_> {
     }
 
     /// Returns the qubit at a given index.
-    pub fn qubit(&self, index: usize) -> Qubit {
+    pub fn qubit(&self, index: usize) -> Qubit<'_> {
         assert!(index < self.size);
         Qubit {
             index: self.base + index,
@@ -41,7 +41,7 @@ impl QuantumRegister<'_> {
     }
 
     /// Returns an iterator over all qubits in this register.
-    pub fn qubits(&self) -> impl Iterator<Item = Qubit> {
+    pub fn qubits(&self) -> impl Iterator<Item = Qubit<'_>> {
         (self.base..self.base + self.size).map(|i| Qubit {
             index: i,
             phantom: PhantomData,

--- a/src/builders/random_circuit.rs
+++ b/src/builders/random_circuit.rs
@@ -53,27 +53,28 @@ where
         .collect_vec();
 
     // Initialize circuit with random qubit states
-    let mut circuit = Circuit::initialize_random(qubits, rng);
+    let mut circuit = Circuit::default();
+    let qr = circuit.allocate_register(qubits);
 
     for _ in 1..rounds {
         for i in 0..qubits {
             // Placing of random single qubit gate
             if rng.sample(single_qubit_die) {
                 let gate = single_qubit_gates.choose(rng).unwrap().clone();
-                circuit.append_gate(gate, &[i]);
+                circuit.append_gate(gate, &[qr.qubit(i)]);
             }
         }
         for (i, j) in &filtered_connectivity {
             // Placing of random two qubit gate
             if rng.sample(two_qubit_die) {
                 let gate = fsim!(0.3, 0.2, false);
-                circuit.append_gate(gate, &[*i, *j]);
+                circuit.append_gate(gate, &[qr.qubit(*i), qr.qubit(*j)]);
             }
         }
     }
 
     // Set up final state
-    circuit.finalize_random(rng)
+    circuit.into_amplitude_network(&"0".repeat(qubits))
 }
 
 /// Creates a random circuit with `rounds` many rounds of single and two qubit gate

--- a/src/builders/random_circuit.rs
+++ b/src/builders/random_circuit.rs
@@ -74,7 +74,7 @@ where
     }
 
     // Set up final state
-    circuit.into_amplitude_network(&"0".repeat(qubits))
+    circuit.into_amplitude_network(&"0".repeat(qubits)).0
 }
 
 /// Creates a random circuit with `rounds` many rounds of single and two qubit gate

--- a/src/qasm/qasm_to_tensornetwork.rs
+++ b/src/qasm/qasm_to_tensornetwork.rs
@@ -1,10 +1,8 @@
-use rustc_hash::FxHashSet;
-
+use crate::builders::circuit_builder::Circuit;
 use crate::qasm::{
     ast::Visitor, expression_folder::ExpressionFolder, gate_inliner::GateInliner,
     include_resolver::expand_includes, parser::parse, tn_creator::TensorNetworkCreator,
 };
-use crate::tensornetwork::tensor::Tensor;
 
 /// Creates a tensor network from QASM2 code.
 ///
@@ -12,7 +10,7 @@ use crate::tensornetwork::tensor::Tensor;
 /// all qubits are initialized to zero, this method adds a tensor for all initial
 /// states. The tensor network is not closed, i.e. for each wire in the circuit there
 /// is an unbounded leg.
-pub fn create_tensornetwork<S>(code: S) -> (Tensor, FxHashSet<usize>)
+pub fn create_tensornetwork<S>(code: S) -> Circuit
 where
     S: Into<String>,
 {
@@ -116,7 +114,8 @@ mod tests {
         h q[0];
         cx q[0], q[1];
         ";
-        let (tn, _) = create_tensornetwork(code);
+        let circuit = create_tensornetwork(code);
+        let tn = circuit.into_amplitude_network("**");
 
         let (kets, single_qubit_gates, two_qubit_gates) = get_quantum_tensors(&tn);
         let [k0, k1] = kets.as_slice() else { panic!() };
@@ -166,7 +165,8 @@ mod tests {
         h q[0];
         cx q[0], q[1];
         ";
-        let (tn, _) = create_tensornetwork(code);
+        let circuit = create_tensornetwork(code);
+        let tn = circuit.into_amplitude_network("**");
         let opt_path = (1..tn.tensors().len())
             .map(|tid| ContractionIndex::Pair(0, tid))
             .collect_vec();
@@ -199,7 +199,8 @@ mod tests {
         x q[0];
         myswap q[1], q[0];
         ";
-        let (tn, _) = create_tensornetwork(code);
+        let circuit = create_tensornetwork(code);
+        let tn = circuit.into_amplitude_network("**");
         let opt_path = (1..tn.tensors().len())
             .map(|tid| ContractionIndex::Pair(0, tid))
             .collect_vec();

--- a/src/qasm/qasm_to_tensornetwork.rs
+++ b/src/qasm/qasm_to_tensornetwork.rs
@@ -34,7 +34,7 @@ where
     expression_folder.visit_program(&mut program);
 
     // Create the tensornetwork
-    let mut tn_creator = TensorNetworkCreator::default();
+    let mut tn_creator = TensorNetworkCreator;
     tn_creator.create_tensornetwork(&program)
 }
 

--- a/src/qasm/tn_creator.rs
+++ b/src/qasm/tn_creator.rs
@@ -7,7 +7,7 @@ use crate::tensornetwork::tensordata::TensorData;
 use crate::utils::traits::HashMapInsertNew;
 
 /// Struct to create a tensor network from an QASM2 AST.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct TensorNetworkCreator;
 
 impl TensorNetworkCreator {


### PR DESCRIPTION
Improve the circuit builder with a method to get specific amplitudes or keep some qubits open to get partial statevectors. Also adds a `Permutor` to make sure the final data is in the expected order.