### PR TITLE
Switch to stable Rust

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,17 +37,17 @@ jobs:
         run: cargo fmt --check
   clippy:
     runs-on: ubuntu-latest
-    name: clippy (nightly)
+    name: clippy (stable)
     steps:
       - name: Install system requirements
         run: sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # tag=v5.0.0
         with:
           submodules: true
-      - name: Install nightly
+      - name: Install stable
         uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # tag=v1.14.1
         with:
-          toolchain: nightly
+          toolchain: stable
           components: clippy
       - name: cargo clippy
         run: cargo clippy --all-features --all-targets
@@ -89,17 +89,17 @@ jobs:
     # cargo-hack checks combinations of feature flags to ensure that features are all additive
     # which is required for feature unification
     runs-on: ubuntu-latest
-    name: features (nightly)
+    name: feature-combinations (stable)
     steps:
       - name: Install system requirements
         run: sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # tag=v5.0.0
         with:
           submodules: true
-      - name: Install nightly
+      - name: Install stable
         uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # tag=v1.14.1
         with:
-          toolchain: nightly
+          toolchain: stable
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@c0dee14250395ae6b1754a99f67c1d693138b102 # tag=v2.58.30
         with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,16 +14,17 @@ name: docs
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: build (stable)
     steps:
       - name: Install system requirements
         run: sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # tag=v5.0.0
         with:
           submodules: true
-      - name: Install nightly
+      - name: Install stable
         uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # tag=v1.14.1
         with:
-          toolchain: nightly
+          toolchain: stable
       - name: cargo doc --no-deps
         run: cargo doc --no-deps
       - name: Add redirect

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ name: test
 jobs:
   required:
     runs-on: ubuntu-latest
-    name: test (nightly)
+    name: test (stable)
     env:
       OMPI_MCA_rmaps_base_oversubscribe: true
     steps:
@@ -34,10 +34,10 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # tag=v5.0.0
         with:
           submodules: true
-      - name: Install nightly
+      - name: Install stable
         uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # tag=v1.14.1
         with:
-          toolchain: nightly
+          toolchain: stable
       - name: cargo generate-lockfile
         # enable this ci template to run regardless of whether the lockfile is checked in or not
         if: hashFiles('Cargo.lock') == ''
@@ -72,7 +72,7 @@ jobs:
     # https://github.com/jonhoo/fantoccini/blob/fde336472b712bc7ebf5b4e772023a7ba71b2262/Cargo.toml#L47-L49.
     # This action is run on ubuntu with the stable toolchain, as it is not expected to fail
     runs-on: ubuntu-latest
-    name: minimal-versions (nightly)
+    name: minimal-versions (stable)
     env:
       OMPI_MCA_rmaps_base_oversubscribe: true
     steps:
@@ -87,10 +87,16 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # tag=v5.0.0
         with:
           submodules: true
-      - name: Install nightly
+      - name: Install stable
+        uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # tag=v1.14.1
+        with:
+          toolchain: stable  
+      - name: Install nightly for -Zdirect-minimal-versions
         uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # tag=v1.14.1
         with:
           toolchain: nightly
+      - name: rustup default stable
+        run: rustup default stable
       - name: cargo update -Zdirect-minimal-versions
         run: cargo +nightly update -Zdirect-minimal-versions
       - name: cargo test
@@ -126,7 +132,7 @@ jobs:
     # use llvm-cov to build and collect coverage and outputs in a format that
     # is compatible with https://github.com/marketplace/actions/code-coverage-summary.
     runs-on: ubuntu-latest
-    name: coverage (nightly)
+    name: coverage (stable)
     env:
       OMPI_MCA_rmaps_base_oversubscribe: true
     steps:
@@ -141,10 +147,10 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # tag=v5.0.0
         with:
           submodules: true
-      - name: Install nightly
+      - name: Install stable
         uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # tag=v1.14.1
         with:
-          toolchain: nightly
+          toolchain: stable
           components: llvm-tools-preview
       - name: cargo install cargo-llvm-cov
         uses: taiki-e/install-action@c0dee14250395ae6b1754a99f67c1d693138b102 # tag=v2.58.30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
     # use llvm-cov to build and collect coverage and outputs in a format that
     # is compatible with https://github.com/marketplace/actions/code-coverage-summary.
     runs-on: ubuntu-latest
-    name: coverage (stable)
+    name: coverage (nightly)
     env:
       OMPI_MCA_rmaps_base_oversubscribe: true
     steps:
@@ -147,10 +147,10 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # tag=v5.0.0
         with:
           submodules: true
-      - name: Install stable
+      - name: Install nightly
         uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # tag=v1.14.1
         with:
-          toolchain: stable
+          toolchain: nightly
           components: llvm-tools-preview
       - name: cargo install cargo-llvm-cov
         uses: taiki-e/install-action@c0dee14250395ae6b1754a99f67c1d693138b102 # tag=v2.58.30

--- a/src/contractionpath/paths/weighted_branchbound.rs
+++ b/src/contractionpath/paths/weighted_branchbound.rs
@@ -1,6 +1,6 @@
 use std::collections::BinaryHeap;
 
-use itertools::{Either, Itertools};
+use itertools::Itertools;
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -144,17 +144,15 @@ impl<'a> WeightedBranchBound<'a> {
                 candidates.push(new_candidate);
             }
         }
-        let candidates = candidates.into_iter_sorted();
-        let candidates = if let Some(limit) = self.nbranch {
-            Either::Left(candidates.take(limit))
-        } else {
-            Either::Right(candidates)
-        };
+        let mut candidates = candidates.into_sorted_vec();
+        if let Some(limit) = self.nbranch {
+            candidates.truncate(limit);
+        }
 
         let mut new_path = Vec::with_capacity(path.len() + 1);
         new_path.extend_from_slice(path);
 
-        for candidate in candidates {
+        for candidate in candidates.into_iter().rev() {
             let Candidate {
                 flop_cost,
                 size_cost,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 //! The partitionings can then be contracted in parallel on a distributed-memory system, as common in high-performance computing.
 //! Local contractions on a single system are also possible.
 
-#![feature(binary_heap_into_iter_sorted)]
-
 extern crate jemallocator;
 
 #[global_allocator]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //! The partitionings can then be contracted in parallel on a distributed-memory system, as common in high-performance computing.
 //! Local contractions on a single system are also possible.
 
-#![feature(assert_matches)]
 #![feature(binary_heap_into_iter_sorted)]
 
 extern crate jemallocator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //! The partitionings can then be contracted in parallel on a distributed-memory system, as common in high-performance computing.
 //! Local contractions on a single system are also possible.
 
-#![feature(map_try_insert)]
 #![feature(assert_matches)]
 #![feature(binary_heap_into_iter_sorted)]
 

--- a/src/tensornetwork/tensor.rs
+++ b/src/tensornetwork/tensor.rs
@@ -563,11 +563,24 @@ impl BitXorAssign<&Tensor> for Tensor {
 mod tests {
     use super::*;
 
-    use std::{assert_matches::assert_matches, iter::zip};
+    use std::iter::zip;
 
     use rustc_hash::FxHashMap;
 
     use crate::tensornetwork::tensordata::TensorData;
+
+    macro_rules! assert_matches {
+        ($left:expr, $pattern:pat) => {
+            match $left {
+                $pattern => (),
+                _ => panic!(
+                    "Expected pattern {} but got {:?}",
+                    stringify!($pattern),
+                    $left
+                ),
+            }
+        };
+    }
 
     #[test]
     fn test_empty_tensor() {

--- a/src/utils/traits.rs
+++ b/src/utils/traits.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::Entry;
 use std::fmt::Debug;
 use std::{
     collections::HashMap,
@@ -23,7 +24,16 @@ where
 {
     #[inline]
     fn insert_new(&mut self, key: K, value: V) {
-        self.try_insert(key, value).unwrap();
+        match self.entry(key) {
+            Entry::Occupied(occupied_entry) => panic!(
+                "can not insert value {value:?}, because there is already an entry ({:?}, {:?})",
+                occupied_entry.key(),
+                occupied_entry.get()
+            ),
+            Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(value);
+            }
+        }
     }
 }
 
@@ -55,9 +65,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "called `Result::unwrap()` on an `Err` value: OccupiedError { key: 1, old_value: 2, new_value: 4, .. }"
-    )]
+    #[should_panic(expected = "can not insert value 4, because there is already an entry (1, 2)")]
     fn test_insert_new_panic() {
         let mut hm = FxHashMap::default();
         hm.insert_new(1, 2);


### PR DESCRIPTION
Stable Rust is preferable, as we can e.g. specify an MSRV in this way. Since nightly was not strictly required for the library, this PR reverts to using stable.