### PR TITLE
Add ContractionPath struct

### DIFF
--- a/tnc/examples/basic_usage.rs
+++ b/tnc/examples/basic_usage.rs
@@ -12,8 +12,7 @@ use tnc::contractionpath::contraction_tree::ContractionTree;
 use tnc::contractionpath::paths::cotengrust::{Cotengrust, OptMethod};
 use tnc::contractionpath::paths::FindPath;
 use tnc::mpi::communication::{
-    broadcast_path, extract_communication_path, intermediate_reduce_tensor_network,
-    scatter_tensor_network,
+    broadcast_path, intermediate_reduce_tensor_network, scatter_tensor_network,
 };
 use tnc::tensornetwork::contraction::contract_tensor_network;
 use tnc::tensornetwork::partitioning::partition_config::PartitioningStrategy;
@@ -93,7 +92,7 @@ fn main() {
         local_tn = contract_tensor_network(local_tn, &local_path);
 
         let mut communication_path = if rank == 0 {
-            extract_communication_path(&path)
+            path.toplevel
         } else {
             Default::default()
         };

--- a/tnc/src/contractionpath/contraction_tree/balancing/balancing_schemes.rs
+++ b/tnc/src/contractionpath/contraction_tree/balancing/balancing_schemes.rs
@@ -697,15 +697,17 @@ mod tests {
         ]);
 
         let contraction_path = path![
+            {
             (0, [(0, 1)]),
             (1, [(0, 1), (0, 2)]),
             (2, [(0, 3), (2, 1), (0, 2)]),
+            },
             (0, 1),
             (0, 2)
         ];
 
         (
-            ContractionTree::from_contraction_path(&tensor15, contraction_path),
+            ContractionTree::from_contraction_path(&tensor15, &contraction_path),
             tensor15,
         )
     }

--- a/tnc/src/contractionpath/contraction_tree/export.rs
+++ b/tnc/src/contractionpath/contraction_tree/export.rs
@@ -11,12 +11,9 @@ use std::{
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
 
-use crate::contractionpath::{
-    contraction_tree::{
-        import::{CommunicationEvent, Direction},
-        ContractionTree,
-    },
-    ContractionIndex,
+use crate::contractionpath::contraction_tree::{
+    import::{CommunicationEvent, Direction},
+    ContractionTree,
 };
 use crate::tensornetwork::tensor::Tensor;
 use crate::utils::traits::HashMapInsertNew;
@@ -72,7 +69,6 @@ pub fn to_dendogram_format(
 
     let root_id = contraction_tree.root_id().unwrap();
     let path = contraction_tree.to_flat_contraction_path(root_id, false);
-    let mut path_iter = path.iter();
 
     let partition_nodes = contraction_tree.partitions.get(&1).unwrap();
     let partitions = partition_nodes
@@ -191,7 +187,7 @@ pub fn to_dendogram_format(
         intermediate_tensors.insert_new(parent_id, parent_tensor);
     };
 
-    while let Some(ContractionIndex::Pair(i, j)) = path_iter.next() {
+    for (i, j) in &path {
         update(i, j, &mut dendogram_entries, &mut id_to_partition);
     }
 
@@ -362,7 +358,7 @@ pub fn to_dendogram(
     };
     let mut node_iter = path.iter().peekable();
 
-    while let Some(ContractionIndex::Pair(i, j)) = node_iter.next() {
+    while let Some((i, j)) = node_iter.next() {
         if node_iter.peek().is_none() {
             plot(i, j, true);
         } else {

--- a/tnc/src/contractionpath/contraction_tree/import.rs
+++ b/tnc/src/contractionpath/contraction_tree/import.rs
@@ -14,13 +14,10 @@ use itertools::Itertools;
 use regex::RegexSet;
 use rustc_hash::FxHashMap;
 
-use crate::contractionpath::{
-    contraction_tree::{
-        export::{to_pdf, DendogramEntry, COLORS, COMMUNICATION_COLOR},
-        node::{child_node, parent_node, NodeRef},
-        ContractionTree,
-    },
-    ContractionIndex,
+use crate::contractionpath::contraction_tree::{
+    export::{to_pdf, DendogramEntry, COLORS, COMMUNICATION_COLOR},
+    node::{child_node, parent_node, NodeRef},
+    ContractionTree,
 };
 use crate::utils::traits::HashMapInsertNew;
 
@@ -51,50 +48,48 @@ pub fn logs_to_pdf(filename: &str, suffix: &str, ranks: usize, output: &str) {
     let mut next_x = 0f64;
     let mut tensor_x_position = FxHashMap::default();
 
-    for contraction_index in &flat_contraction_path {
-        if let ContractionIndex::Pair(i, j) = contraction_index {
-            if contraction_tree.node(*i).is_leaf() {
-                tensor_x_position.insert_new(*i, next_x);
-                dendogram_entries.push(DendogramEntry {
-                    id: *i,
-                    x: tensor_x_position[i],
-                    y: 0f64,
-                    cost: 0f64,
-                    color: tensor_color[i].clone(),
-                    children: None,
-                });
-                next_x += 1f64;
-            }
+    for (i, j) in &flat_contraction_path {
+        if contraction_tree.node(*i).is_leaf() {
+            tensor_x_position.insert_new(*i, next_x);
+            dendogram_entries.push(DendogramEntry {
+                id: *i,
+                x: tensor_x_position[i],
+                y: 0f64,
+                cost: 0f64,
+                color: tensor_color[i].clone(),
+                children: None,
+            });
+            next_x += 1f64;
+        }
 
-            if contraction_tree.node(*j).is_leaf() {
-                tensor_x_position.insert_new(*j, next_x);
-                dendogram_entries.push(DendogramEntry {
-                    id: *j,
-                    x: tensor_x_position[j],
-                    y: 0f64,
-                    cost: 0f64,
-                    color: tensor_color[j].clone(),
-                    children: None,
-                });
-                next_x += 1f64;
-            }
+        if contraction_tree.node(*j).is_leaf() {
+            tensor_x_position.insert_new(*j, next_x);
+            dendogram_entries.push(DendogramEntry {
+                id: *j,
+                x: tensor_x_position[j],
+                y: 0f64,
+                cost: 0f64,
+                color: tensor_color[j].clone(),
+                children: None,
+            });
+            next_x += 1f64;
+        }
 
-            let x1 = tensor_x_position[i];
-            let x2 = tensor_x_position[j];
-            let new_x = (x1 + x2) / 2.;
-            if let Some(parent_id) = contraction_tree.node(*i).parent_id() {
-                let y = tensor_position[&parent_id];
-                let color = tensor_color[&parent_id].clone();
-                dendogram_entries.push(DendogramEntry {
-                    id: parent_id,
-                    x: new_x,
-                    y,
-                    cost: y,
-                    color,
-                    children: Some((*i, *j)),
-                });
-                tensor_x_position.insert_new(parent_id, new_x);
-            }
+        let x1 = tensor_x_position[i];
+        let x2 = tensor_x_position[j];
+        let new_x = (x1 + x2) / 2.;
+        if let Some(parent_id) = contraction_tree.node(*i).parent_id() {
+            let y = tensor_position[&parent_id];
+            let color = tensor_color[&parent_id].clone();
+            dendogram_entries.push(DendogramEntry {
+                id: parent_id,
+                x: new_x,
+                y,
+                cost: y,
+                color,
+                children: Some((*i, *j)),
+            });
+            tensor_x_position.insert_new(parent_id, new_x);
         }
     }
 

--- a/tnc/src/contractionpath/paths/tree_annealing.rs
+++ b/tnc/src/contractionpath/paths/tree_annealing.rs
@@ -6,7 +6,7 @@ use crate::{
     contractionpath::{
         contraction_cost::contract_path_cost,
         paths::{CostType, FindPath},
-        ssa_replace_ordering, ContractionIndex,
+        ssa_replace_ordering, ContractionPath,
     },
     tensornetwork::tensor::Tensor,
 };
@@ -19,7 +19,7 @@ pub struct TreeAnnealing<'a> {
     numiter: Option<usize>,
     best_flops: f64,
     best_size: f64,
-    best_path: Vec<ContractionIndex>,
+    best_path: ContractionPath,
     seed: Option<u64>,
 }
 
@@ -43,7 +43,7 @@ impl<'a> TreeAnnealing<'a> {
             numiter,
             best_flops: f64::INFINITY,
             best_size: f64::INFINITY,
-            best_path: vec![],
+            best_path: ContractionPath::default(),
             seed,
         }
     }
@@ -82,10 +82,7 @@ impl FindPath for TreeAnnealing<'_> {
 
         let best_path = replace_to_ssa_path(replace_path, self.tensor.tensors().len());
 
-        self.best_path = best_path
-            .iter()
-            .map(|(i, j)| ContractionIndex::Pair(*i, *j))
-            .collect_vec();
+        self.best_path = ContractionPath::simple(best_path);
 
         let (op_cost, mem_cost) =
             contract_path_cost(self.tensor.tensors(), &self.get_best_replace_path(), true);
@@ -102,12 +99,12 @@ impl FindPath for TreeAnnealing<'_> {
         self.best_size
     }
 
-    fn get_best_path(&self) -> &Vec<ContractionIndex> {
+    fn get_best_path(&self) -> &ContractionPath {
         &self.best_path
     }
 
-    fn get_best_replace_path(&self) -> Vec<ContractionIndex> {
-        ssa_replace_ordering(&self.best_path, self.tensor.tensors().len())
+    fn get_best_replace_path(&self) -> ContractionPath {
+        ssa_replace_ordering(&self.best_path)
     }
 }
 

--- a/tnc/src/contractionpath/paths/tree_reconfiguration.rs
+++ b/tnc/src/contractionpath/paths/tree_reconfiguration.rs
@@ -8,7 +8,7 @@ use crate::{
     contractionpath::{
         contraction_cost::contract_path_cost,
         paths::{CostType, FindPath},
-        ssa_replace_ordering, ContractionIndex,
+        ssa_replace_ordering, ContractionPath,
     },
     tensornetwork::tensor::Tensor,
 };
@@ -20,7 +20,7 @@ pub struct TreeReconfigure<'a> {
     subtree_size: usize,
     best_flops: f64,
     best_size: f64,
-    best_path: Vec<ContractionIndex>,
+    best_path: ContractionPath,
 }
 
 impl<'a> TreeReconfigure<'a> {
@@ -39,7 +39,7 @@ impl<'a> TreeReconfigure<'a> {
             subtree_size,
             best_flops: f64::INFINITY,
             best_size: f64::INFINITY,
-            best_path: vec![],
+            best_path: ContractionPath::default(),
         }
     }
 }
@@ -70,10 +70,7 @@ impl FindPath for TreeReconfigure<'_> {
 
         let best_path = replace_to_ssa_path(replace_path, self.tensor.tensors().len());
 
-        self.best_path = best_path
-            .iter()
-            .map(|(i, j)| ContractionIndex::Pair(*i, *j))
-            .collect_vec();
+        self.best_path = ContractionPath::simple(best_path);
 
         let (op_cost, mem_cost) =
             contract_path_cost(self.tensor.tensors(), &self.get_best_replace_path(), true);
@@ -90,12 +87,12 @@ impl FindPath for TreeReconfigure<'_> {
         self.best_size
     }
 
-    fn get_best_path(&self) -> &Vec<ContractionIndex> {
+    fn get_best_path(&self) -> &ContractionPath {
         &self.best_path
     }
 
-    fn get_best_replace_path(&self) -> Vec<ContractionIndex> {
-        ssa_replace_ordering(&self.best_path, self.tensor.tensors().len())
+    fn get_best_replace_path(&self) -> ContractionPath {
+        ssa_replace_ordering(&self.best_path)
     }
 }
 

--- a/tnc/src/contractionpath/paths/tree_tempering.rs
+++ b/tnc/src/contractionpath/paths/tree_tempering.rs
@@ -8,7 +8,7 @@ use crate::{
     contractionpath::{
         contraction_cost::contract_path_cost,
         paths::{CostType, FindPath},
-        ssa_replace_ordering, ContractionIndex,
+        ssa_replace_ordering, ContractionPath,
     },
     tensornetwork::tensor::Tensor,
 };
@@ -20,7 +20,7 @@ pub struct TreeTempering<'a> {
     numiter: Option<usize>,
     best_flops: f64,
     best_size: f64,
-    best_path: Vec<ContractionIndex>,
+    best_path: ContractionPath,
     seed: Option<u64>,
 }
 
@@ -42,7 +42,7 @@ impl<'a> TreeTempering<'a> {
             numiter,
             best_flops: f64::INFINITY,
             best_size: f64::INFINITY,
-            best_path: vec![],
+            best_path: ContractionPath::default(),
             seed,
         }
     }
@@ -74,10 +74,7 @@ impl FindPath for TreeTempering<'_> {
 
         let best_path = replace_to_ssa_path(replace_path, self.tensor.tensors().len());
 
-        self.best_path = best_path
-            .iter()
-            .map(|(i, j)| ContractionIndex::Pair(*i, *j))
-            .collect_vec();
+        self.best_path = ContractionPath::simple(best_path);
 
         let (op_cost, mem_cost) =
             contract_path_cost(self.tensor.tensors(), &self.get_best_replace_path(), true);
@@ -94,12 +91,12 @@ impl FindPath for TreeTempering<'_> {
         self.best_size
     }
 
-    fn get_best_path(&self) -> &Vec<ContractionIndex> {
+    fn get_best_path(&self) -> &ContractionPath {
         &self.best_path
     }
 
-    fn get_best_replace_path(&self) -> Vec<ContractionIndex> {
-        ssa_replace_ordering(&self.best_path, self.tensor.tensors().len())
+    fn get_best_replace_path(&self) -> ContractionPath {
+        ssa_replace_ordering(&self.best_path)
     }
 }
 

--- a/tnc/src/contractionpath/paths/weighted_branchbound.rs
+++ b/tnc/src/contractionpath/paths/weighted_branchbound.rs
@@ -8,7 +8,7 @@ use crate::{
         candidates::Candidate,
         contraction_cost::{contract_op_cost_tensors, contract_size_tensors},
         paths::{CostType, FindPath},
-        ssa_ordering, ssa_replace_ordering, ContractionIndex,
+        ssa_ordering, ssa_replace_ordering, ContractionPath,
     },
     tensornetwork::tensor::Tensor,
     utils::traits::HashMapInsertNew,
@@ -22,7 +22,7 @@ pub struct WeightedBranchBound<'a> {
     minimize: CostType,
     best_flops: f64,
     best_size: f64,
-    best_path: Vec<ContractionIndex>,
+    best_path: ContractionPath,
     best_progress: FxHashMap<usize, f64>,
     largest_latency: f64,
     result_cache: FxHashMap<(usize, usize), (usize, f64, f64)>,
@@ -45,7 +45,7 @@ impl<'a> WeightedBranchBound<'a> {
             minimize,
             best_flops: f64::INFINITY,
             best_size: f64::INFINITY,
-            best_path: Vec::new(),
+            best_path: ContractionPath::default(),
             best_progress: FxHashMap::default(),
             largest_latency: Default::default(),
             result_cache: FxHashMap::default(),
@@ -182,7 +182,7 @@ impl FindPath for WeightedBranchBound<'_> {
             .max_by(|a, b| a.1.partial_cmp(b.1).expect("Tried to compare NaN"))
             .unwrap()
             .1;
-        let mut sub_tensor_contraction = Vec::new();
+        let mut nested_paths = FxHashMap::default();
         // Get the initial space requirements for uncontracted tensors
         for (index, mut tensor) in tensors.into_iter().enumerate() {
             // Check that tensor has sub-tensors and doesn't have external legs set
@@ -195,16 +195,17 @@ impl FindPath for WeightedBranchBound<'_> {
                     self.minimize,
                 );
                 bb.find_path();
-                sub_tensor_contraction
-                    .push(ContractionIndex::Path(index, bb.get_best_path().clone()));
+                nested_paths.insert(index, bb.get_best_path().clone());
                 tensor = tensor.external_tensor();
             }
             self.tensor_cache.insert_new(index, tensor);
         }
         let remaining = (0..self.tn.tensors().len()).collect_vec();
         self.branch_iterate(&[], &remaining, 0f64, 0f64);
-        sub_tensor_contraction.extend_from_slice(&self.best_path);
-        self.best_path = sub_tensor_contraction;
+        self.best_path = ContractionPath {
+            nested: nested_paths,
+            toplevel: std::mem::take(&mut self.best_path).into_simple(),
+        };
     }
 
     fn get_best_flops(&self) -> f64 {
@@ -215,12 +216,12 @@ impl FindPath for WeightedBranchBound<'_> {
         self.best_size
     }
 
-    fn get_best_path(&self) -> &Vec<ContractionIndex> {
+    fn get_best_path(&self) -> &ContractionPath {
         &self.best_path
     }
 
-    fn get_best_replace_path(&self) -> Vec<ContractionIndex> {
-        ssa_replace_ordering(&self.best_path, self.tn.tensors().len())
+    fn get_best_replace_path(&self) -> ContractionPath {
+        ssa_replace_ordering(&self.best_path)
     }
 }
 

--- a/tnc/src/qasm/qasm_importer.rs
+++ b/tnc/src/qasm/qasm_importer.rs
@@ -44,12 +44,11 @@ mod tests {
     use std::f64::consts::FRAC_1_SQRT_2;
 
     use float_cmp::assert_approx_eq;
-    use itertools::Itertools;
     use num_complex::{c64, Complex64};
 
     use crate::{
         builders::circuit_builder::Permutor,
-        contractionpath::ContractionIndex,
+        contractionpath::ContractionPath,
         tensornetwork::{
             contraction::contract_tensor_network,
             tensor::{EdgeIndex, Tensor, TensorIndex},
@@ -162,9 +161,8 @@ mod tests {
     /// Contracts the tensor network with an arbitrary contraction order, then
     /// returns the correctly permuted tensor data.
     fn contract_tn(tn: Tensor, perm: Permutor) -> TensorData {
-        let opt_path = (1..tn.tensors().len())
-            .map(|tid| ContractionIndex::Pair(0, tid))
-            .collect_vec();
+        let opt_path =
+            ContractionPath::simple((1..tn.tensors().len()).map(|tid| (0, tid)).collect());
         let tn = contract_tensor_network(tn, &opt_path);
         let mut tn = perm.apply(tn);
         std::mem::take(&mut tn.tensordata)

--- a/tnc/src/tensornetwork/partitioning.rs
+++ b/tnc/src/tensornetwork/partitioning.rs
@@ -87,7 +87,7 @@ pub fn find_partitioning(
 }
 
 /// Repeatedly partitions a tensor network to identify a communication scheme.
-/// Returns a `Vec<ContractionIndex>` of length equal to the number of input tensors minus one, acts as a communication scheme.
+/// Returns a `Vec<usize>` of length equal to the number of input tensors minus one, acts as a communication scheme.
 ///
 /// # Arguments
 ///

--- a/tnc/tests/integration_tests.rs
+++ b/tnc/tests/integration_tests.rs
@@ -9,8 +9,7 @@ use tnc::{
         FindPath,
     },
     mpi::communication::{
-        broadcast_path, extract_communication_path, intermediate_reduce_tensor_network,
-        scatter_tensor_network,
+        broadcast_path, intermediate_reduce_tensor_network, scatter_tensor_network,
     },
     tensornetwork::{
         contraction::contract_tensor_network,
@@ -114,7 +113,7 @@ fn test_partitioned_contraction_need_mpi() {
     local_tn = contract_tensor_network(local_tn, &local_path);
 
     let mut communication_path = if rank == 0 {
-        extract_communication_path(&path)
+        path.toplevel
     } else {
         Default::default()
     };


### PR DESCRIPTION
This makes handling hierarchical contraction paths a bit nicer. In particular, it clearly separates the nested paths and the top-level path, rendering code to e.g. extract the top-level path unnecessary.

In general, the order of nested contractions and top level contractions is not important to our code, the only requirement was that composite tensors need to be contracted to leaf tensors because they are used in a top-level contraction. Hence, the order and position of nested contractions in the contraction path was useless information. Now, the nested contraction paths don't have an order and they are separated from the top-level path.

At the same time, it gives a bit more type expressiveness, as it can now be expressed whether a flat path (SimplePath) is taken / returned or a hierarchical path (ContractionPath).