### PR TITLE
Remove code coverage CI for benchmark crate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,7 +179,7 @@ jobs:
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: cargo llvm-cov
-        run: cargo llvm-cov --locked --all-features --workspace --lcov --output-path coverage.lcov --ignore-filename-regex generated --doctests
+        run: cargo llvm-cov --locked --all-features -p tnc --lcov --output-path coverage.lcov --ignore-filename-regex generated --doctests
       - name: Check 75% test coverage
         uses: tluijken/code-coverage-threshold@905bb53afdaea38a54d1a7a19c75c1ff513a3b07 # tag=v1
         with:


### PR DESCRIPTION
The benchmark crate is not really relevant to the library, and the coverage sometimes caused problems.