### PR TITLE
Use explicit structs for Composite and Leaf tensors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,11 +77,13 @@ jobs:
     name: minimal-versions (stable)
     env:
       OMPI_MCA_rmaps_base_oversubscribe: true
+      CXXFLAGS: "-mno-avx512f -mno-avx512bw -mno-avx512vl"
+      CFLAGS: "-mno-avx512f -mno-avx512bw -mno-avx512vl"
     steps:
       - name: Install system requirements
         run: |
           sudo apt-get update
-          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev
+          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev gdb
       - name: Install python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # tag=v6.3.0
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,6 +1918,7 @@ version = "1.0.1"
 dependencies = [
  "antlr-rust",
  "approx",
+ "bytemuck",
  "cotengrust",
  "flexi_logger",
  "genetic_algorithm",

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ use tnc::{
 fn main() {
     // The QASM code prepares a GHZ state
     let code = "\
-OPENQASM 2.0;
-include \"qelib1.inc\";
+    OPENQASM 2.0;
+    include \"qelib1.inc\";
 
-qreg q[3];
-h q[0];
-cx q[0], q[1];
-cx q[1], q[2];
-";
+    qreg q[3];
+    h q[0];
+    cx q[0], q[1];
+    cx q[1], q[2];
+    ";
 
     // Create a Circuit instance out of the code
     let circuit = import_qasm(code);
@@ -67,7 +67,7 @@ cx q[1], q[2];
     let statevector = permutator.apply(final_tensor);
 
     // Get the actual data.
-    let data = statevector.into_tensor_data().into_data();
+    let data = statevector.into_data().into_data();
 
     // Print the data
     println!("Resulting statevector is: {:?}", data);

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -52,7 +52,7 @@ use tnc::mpi::communication::{
 };
 use tnc::tensornetwork::contraction::contract_tensor_network;
 use tnc::tensornetwork::partitioning::{find_partitioning, PartitioningStrategy};
-use tnc::tensornetwork::tensor::Tensor;
+use tnc::tensornetwork::tensor::{CompositeTensor, LeafTensor};
 use utils::{hash_str, parse_range_list, setup_logging_mpi};
 
 mod cli;
@@ -63,8 +63,8 @@ mod utils;
 const TIME_LIMIT: Duration = Duration::from_secs(10 * 60);
 
 /// Reads a circuit from the given qasm file.
-fn read_circuit(file: &str) -> Tensor {
-    static LAST_RETURN: Mutex<Option<(String, Tensor)>> = Mutex::new(None);
+fn read_circuit(file: &str) -> CompositeTensor {
+    static LAST_RETURN: Mutex<Option<(String, CompositeTensor)>> = Mutex::new(None);
     let mut last_values = LAST_RETURN.lock().unwrap();
     if let Some((arg, out)) = &*last_values {
         if arg == file {
@@ -223,7 +223,7 @@ fn main() {
 fn write_to_cache(
     directory: &str,
     key: &str,
-    partitioned_tensor: &Tensor,
+    partitioned_tensor: &CompositeTensor,
     contraction_path: &ContractionPath,
 ) {
     let file = fs::File::create(format!("{directory}/{key}")).unwrap();
@@ -233,7 +233,7 @@ fn write_to_cache(
         .unwrap();
 }
 
-fn read_from_cache(directory: &str, key: &str) -> (Tensor, ContractionPath) {
+fn read_from_cache(directory: &str, key: &str) -> (CompositeTensor, ContractionPath) {
     let file = fs::File::open(format!("{directory}/{key}")).unwrap();
     let mut stream = ZlibDecoder::new(file);
     let (deserializable, path) =
@@ -243,7 +243,7 @@ fn read_from_cache(directory: &str, key: &str) -> (Tensor, ContractionPath) {
 
 /// Computes the flops and memory when using Greedy without partitioning.
 /// Uses the file as a cache key.
-fn serial_cost(tensor: &Tensor, file: &str) -> (f64, f64) {
+fn serial_cost(tensor: &CompositeTensor, file: &str) -> (f64, f64) {
     static LAST_RETURN: Mutex<Option<(String, (f64, f64))>> = Mutex::new(None);
     let mut last_values = LAST_RETURN.lock().unwrap();
     if let Some((arg, out)) = &*last_values {
@@ -352,7 +352,10 @@ fn do_run(
     std::hint::black_box(final_tensor);
 }
 
-fn local_contraction(tensor: Tensor, contraction_path: &ContractionPath) -> (Tensor, Duration) {
+fn local_contraction(
+    tensor: CompositeTensor,
+    contraction_path: &ContractionPath,
+) -> (LeafTensor, Duration) {
     let t0 = Instant::now();
     let result = contract_tensor_network(tensor, contraction_path);
     let duration = t0.elapsed();
@@ -360,10 +363,10 @@ fn local_contraction(tensor: Tensor, contraction_path: &ContractionPath) -> (Ten
 }
 
 fn perform_contraction(
-    partitioned_tensor: &Tensor,
+    partitioned_tensor: &CompositeTensor,
     contraction_path: &ContractionPath,
     world: &SimpleCommunicator,
-) -> (Tensor, Duration) {
+) -> (LeafTensor, Duration) {
     let rank = world.rank();
     let root = world.process_at_rank(0);
     world.barrier();
@@ -382,7 +385,7 @@ fn perform_contraction(
     broadcast_path(&mut communication_path, &root);
 
     // Distribute tensor network
-    let (mut local_tn, local_path, comm) = scatter_tensor_network(
+    let (local_tn, local_path, comm) = scatter_tensor_network(
         partitioned_tensor,
         contraction_path,
         rank,
@@ -391,7 +394,7 @@ fn perform_contraction(
     );
 
     // Contract the local tensor network
-    local_tn = contract_tensor_network(local_tn, &local_path);
+    let mut local_tn = contract_tensor_network(local_tn, &local_path);
 
     // Reduce the tensor network
     intermediate_reduce_tensor_network(&mut local_tn, &communication_path, rank, world, &comm);
@@ -414,24 +417,24 @@ trait MethodRun {
     /// contraction path and the number of operations it takes to constract.
     fn run(
         &self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         num_partitions: i32,
         initial_partitioning: &[usize],
         communication_scheme: CommunicationScheme,
         rng: &mut StdRng,
-    ) -> (Tensor, ContractionPath, f64, f64);
+    ) -> (CompositeTensor, ContractionPath, f64, f64);
 
     /// Runs the method on the given tensor, returning the partitioned tensor, the
     /// contraction path, the number of operations it takes to constract and the
     /// time it took to run the method.
     fn timed_run(
         &self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         num_partitions: i32,
         initial_partitioning: &[usize],
         communication_scheme: CommunicationScheme,
         rng: &mut StdRng,
-    ) -> ((Tensor, ContractionPath, f64, f64), Duration) {
+    ) -> ((CompositeTensor, ContractionPath, f64, f64), Duration) {
         let t0 = Instant::now();
         let result = self.run(
             tensor,
@@ -455,12 +458,12 @@ impl MethodRun for Generic {
 
     fn run(
         &self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         _num_partitions: i32,
         initial_partitioning: &[usize],
         communication_scheme: CommunicationScheme,
         rng: &mut StdRng,
-    ) -> (Tensor, ContractionPath, f64, f64) {
+    ) -> (CompositeTensor, ContractionPath, f64, f64) {
         let (
             initial_partitioned_tensor,
             initial_contraction_path,
@@ -491,12 +494,12 @@ impl MethodRun for Sa {
 
     fn run(
         &self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         num_partitions: i32,
         initial_partitioning: &[usize],
         communication_scheme: CommunicationScheme,
         rng: &mut StdRng,
-    ) -> (Tensor, ContractionPath, f64, f64) {
+    ) -> (CompositeTensor, ContractionPath, f64, f64) {
         let (partitioning, _) = simulated_annealing::balance_partitions(
             NaivePartitioningModel {
                 tensor,
@@ -530,12 +533,12 @@ impl MethodRun for Ia {
 
     fn run(
         &self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         num_partitions: i32,
         initial_partitioning: &[usize],
         communication_scheme: CommunicationScheme,
         rng: &mut StdRng,
-    ) -> (Tensor, ContractionPath, f64, f64) {
+    ) -> (CompositeTensor, ContractionPath, f64, f64) {
         let (_, initial_contraction_path, _, _) = compute_solution(
             tensor,
             initial_partitioning,
@@ -582,15 +585,15 @@ impl MethodRun for Sad {
 
     fn run(
         &self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         num_partitions: i32,
         initial_partitioning: &[usize],
         communication_scheme: CommunicationScheme,
         rng: &mut StdRng,
-    ) -> (Tensor, ContractionPath, f64, f64) {
-        let mut intermediate_tensors = vec![Tensor::default(); num_partitions as usize];
+    ) -> (CompositeTensor, ContractionPath, f64, f64) {
+        let mut intermediate_tensors = vec![LeafTensor::default(); num_partitions as usize];
         for (index, partition) in initial_partitioning.iter().enumerate() {
-            intermediate_tensors[*partition] ^= tensor.tensor(index);
+            intermediate_tensors[*partition] ^= tensor.tensor(index).as_leaf().unwrap();
         }
 
         let (solution, _) = simulated_annealing::balance_partitions(
@@ -626,15 +629,15 @@ impl MethodRun for Iad {
 
     fn run(
         &self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         num_partitions: i32,
         initial_partitioning: &[usize],
         communication_scheme: CommunicationScheme,
         rng: &mut StdRng,
-    ) -> (Tensor, ContractionPath, f64, f64) {
-        let mut intermediate_tensors = vec![Tensor::default(); num_partitions as usize];
+    ) -> (CompositeTensor, ContractionPath, f64, f64) {
+        let mut intermediate_tensors = vec![LeafTensor::default(); num_partitions as usize];
         for (index, partition) in initial_partitioning.iter().enumerate() {
-            intermediate_tensors[*partition] ^= tensor.tensor(index);
+            intermediate_tensors[*partition] ^= tensor.tensor(index).as_leaf().unwrap();
         }
 
         let (_, initial_contraction_path, _, _) = compute_solution(
@@ -683,7 +686,7 @@ struct GreedyBalance {
     balancing_scheme: BalancingScheme,
 }
 #[allow(dead_code)]
-fn objective_function(a: &Tensor, b: &Tensor) -> f64 {
+fn objective_function(a: &LeafTensor, b: &LeafTensor) -> f64 {
     a.size() + b.size() - (a ^ b).size()
 }
 impl MethodRun for GreedyBalance {
@@ -697,12 +700,12 @@ impl MethodRun for GreedyBalance {
 
     fn run(
         &self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         _num_partitions: i32,
         initial_partitioning: &[usize],
         communication_scheme: CommunicationScheme,
         rng: &mut StdRng,
-    ) -> (Tensor, ContractionPath, f64, f64) {
+    ) -> (CompositeTensor, ContractionPath, f64, f64) {
         let (initial_partitioned_tensor, initial_contraction_path, _, _) = compute_solution(
             tensor,
             initial_partitioning,
@@ -749,22 +752,26 @@ impl MethodRun for CotengraTempering {
 
     fn run(
         &self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         _num_partitions: i32,
         _initial_partitioning: &[usize],
         _communication_scheme: CommunicationScheme,
         rng: &mut StdRng,
-    ) -> (Tensor, ContractionPath, f64, f64) {
+    ) -> (CompositeTensor, ContractionPath, f64, f64) {
         let seed = rng.next_u64();
         let mut tree = TreeTempering::new(Some(seed), CostType::Flops, Some(300));
         let result = tree.find_path(tensor);
         let best_path = result.replace_path();
         let best_path_simple = best_path.clone().into_simple();
 
+        let leaves = tensor
+            .tensors()
+            .iter()
+            .map(|t| t.clone().into_leaf().unwrap())
+            .collect_vec();
         let (parallel_flops, _) =
-            communication_path_cost(tensor.tensors(), &best_path_simple, true, true, None);
-        let (sum_flops, _) =
-            communication_path_cost(tensor.tensors(), &best_path_simple, true, false, None);
+            communication_path_cost(&leaves, &best_path_simple, true, true, None);
+        let (sum_flops, _) = communication_path_cost(&leaves, &best_path_simple, true, false, None);
 
         (tensor.clone(), best_path, parallel_flops, sum_flops)
     }
@@ -784,22 +791,26 @@ impl MethodRun for CotengraAnneal {
 
     fn run(
         &self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         _num_partitions: i32,
         _initial_partitioning: &[usize],
         _communication_scheme: CommunicationScheme,
         rng: &mut StdRng,
-    ) -> (Tensor, ContractionPath, f64, f64) {
+    ) -> (CompositeTensor, ContractionPath, f64, f64) {
         let seed = rng.next_u64();
         let mut tree = TreeAnnealing::new(Some(seed), CostType::Flops, Some(300), Some(100));
         let result = tree.find_path(tensor);
         let best_path = result.replace_path();
         let best_path_simple = best_path.clone().into_simple();
 
+        let leaves = tensor
+            .tensors()
+            .iter()
+            .map(|t| t.clone().into_leaf().unwrap())
+            .collect_vec();
         let (parallel_flops, _) =
-            communication_path_cost(tensor.tensors(), &best_path_simple, true, true, None);
-        let (sum_flops, _) =
-            communication_path_cost(tensor.tensors(), &best_path_simple, true, false, None);
+            communication_path_cost(&leaves, &best_path_simple, true, true, None);
+        let (sum_flops, _) = communication_path_cost(&leaves, &best_path_simple, true, false, None);
         (tensor.clone(), best_path, parallel_flops, sum_flops)
     }
 }
@@ -818,12 +829,12 @@ impl MethodRun for CotengraHyper {
 
     fn run(
         &self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         _num_partitions: i32,
         _initial_partitioning: &[usize],
         _communication_scheme: CommunicationScheme,
         _rng: &mut StdRng,
-    ) -> (Tensor, ContractionPath, f64, f64) {
+    ) -> (CompositeTensor, ContractionPath, f64, f64) {
         let mut tree = Hyperoptimizer::new(
             CostType::Flops,
             HyperOptions::new()
@@ -834,10 +845,14 @@ impl MethodRun for CotengraHyper {
         let best_path = result.replace_path();
         let best_path_simple = best_path.clone().into_simple();
 
+        let leaves = tensor
+            .tensors()
+            .iter()
+            .map(|t| t.clone().into_leaf().unwrap())
+            .collect_vec();
         let (parallel_flops, _) =
-            communication_path_cost(tensor.tensors(), &best_path_simple, true, true, None);
-        let (sum_flops, _) =
-            communication_path_cost(tensor.tensors(), &best_path_simple, true, false, None);
+            communication_path_cost(&leaves, &best_path_simple, true, true, None);
+        let (sum_flops, _) = communication_path_cost(&leaves, &best_path_simple, true, false, None);
 
         (tensor.clone(), best_path, parallel_flops, sum_flops)
     }

--- a/tnc/Cargo.toml
+++ b/tnc/Cargo.toml
@@ -36,6 +36,7 @@ rustengra = { git = "https://github.com/Ectras/rustengra.git", optional = true }
 cotengrust = { git = "https://github.com/Ectras/cotengrust.git", branch = "rust_extension" }
 approx = { version = "0.5.1", features = ["num-complex"] }
 tblis = { git = "https://github.com/Ectras/rust-tblis.git" }
+bytemuck = { version = "1.24.0", features = ["derive", "extern_crate_alloc"] }
 
 [dev-dependencies]
 mpi-test = { git = "https://github.com/Ectras/mpi-test.git" }

--- a/tnc/examples/distributed_contraction.rs
+++ b/tnc/examples/distributed_contraction.rs
@@ -12,7 +12,7 @@ use tnc::{
     tensornetwork::{
         contraction::contract_tensor_network,
         partitioning::{find_partitioning, partition_tensor_network, PartitioningStrategy},
-        tensor::Tensor,
+        tensor::{CompositeTensor, LeafTensor},
     },
 };
 
@@ -40,7 +40,7 @@ fn main() {
     }
 }
 
-fn distributed_contraction(tensor: Tensor, world: &SimpleCommunicator) -> Tensor {
+fn distributed_contraction(tensor: CompositeTensor, world: &SimpleCommunicator) -> LeafTensor {
     let rank = world.rank();
     let size = world.size();
     let root = world.process_at_rank(0);
@@ -69,15 +69,15 @@ fn distributed_contraction(tensor: Tensor, world: &SimpleCommunicator) -> Tensor
     broadcast_path(&mut communication_path, &root);
 
     // Distribute the partitions to the ranks
-    let (mut local_tn, local_path, comm) =
+    let (local_tn, local_path, comm) =
         scatter_tensor_network(&partitioned_tn, &path, rank, size, world);
 
     // Contract the partitions on each rank
-    local_tn = contract_tensor_network(local_tn, &local_path);
+    let mut local_tensor = contract_tensor_network(local_tn, &local_path);
 
     // Perform the final fan-in, sending tensors between ranks and contracting them
     // until there is only the final tensor left, which will end up on rank 0.
-    intermediate_reduce_tensor_network(&mut local_tn, &communication_path, rank, world, &comm);
+    intermediate_reduce_tensor_network(&mut local_tensor, &communication_path, rank, world, &comm);
 
-    local_tn
+    local_tensor
 }

--- a/tnc/examples/local_contraction.rs
+++ b/tnc/examples/local_contraction.rs
@@ -43,7 +43,7 @@ fn main() {
     let statevector = permutator.apply(final_tensor);
 
     // Get the actual data
-    let data = statevector.into_tensor_data().into_data();
+    let data = statevector.into_data().into_data();
 
     // Print the data
     println!("Resulting statevector is: {:?}", data.flatten());

--- a/tnc/examples/repartitioning.rs
+++ b/tnc/examples/repartitioning.rs
@@ -14,11 +14,11 @@ use tnc::{
     },
     tensornetwork::{
         partitioning::{find_partitioning, partition_tensor_network, PartitioningStrategy},
-        tensor::Tensor,
+        tensor::CompositeTensor,
     },
 };
 
-fn compute_cost(tensor: &Tensor, partitioning: &[usize]) -> f64 {
+fn compute_cost(tensor: &CompositeTensor, partitioning: &[usize]) -> f64 {
     // Partition the tensor
     let partitioned_tn = partition_tensor_network(tensor.clone(), partitioning);
 
@@ -33,7 +33,8 @@ fn compute_cost(tensor: &Tensor, partitioning: &[usize]) -> f64 {
         .iter()
         .enumerate()
         .map(|(i, t)| {
-            let (ops, _mem) = contract_path_cost(t.tensors(), &path.nested[&i], true);
+            let (ops, _mem) =
+                contract_path_cost(t.as_composite().unwrap().tensors(), &path.nested[&i], true);
             ops
         })
         .collect::<Vec<_>>();
@@ -42,7 +43,7 @@ fn compute_cost(tensor: &Tensor, partitioning: &[usize]) -> f64 {
     let partition_tensors = partitioned_tn
         .tensors()
         .iter()
-        .map(Tensor::external_tensor)
+        .map(|t| t.as_composite().unwrap().external_tensor())
         .collect::<Vec<_>>();
 
     // Get the contraction cost of contracting the final partition tensors in parallel
@@ -57,7 +58,7 @@ fn compute_cost(tensor: &Tensor, partitioning: &[usize]) -> f64 {
 }
 
 fn rebalance(
-    tensor: &Tensor,
+    tensor: &CompositeTensor,
     initial_partitioning: &[usize],
     rng: &mut StdRng,
     communication_scheme: CommunicationScheme,

--- a/tnc/src/builders/circuit_builder.rs
+++ b/tnc/src/builders/circuit_builder.rs
@@ -8,7 +8,7 @@ use permutation::Permutation;
 
 use crate::{
     tensornetwork::{
-        tensor::{EdgeIndex, Tensor},
+        tensor::{CompositeTensor, EdgeIndex, LeafTensor},
         tensordata::TensorData,
     },
     utils::traits::PermutationToVec,
@@ -86,18 +86,12 @@ impl Permutor {
     }
 
     /// Permutates the tensor according to the stored permutation.
-    pub fn apply(&self, tensor: Tensor) -> Tensor {
-        assert!(tensor.is_leaf());
+    pub fn apply(&self, tensor: LeafTensor) -> LeafTensor {
         if self.is_identity() {
             return tensor;
         }
 
-        let Tensor {
-            mut legs,
-            mut bond_dims,
-            tensordata,
-            ..
-        } = tensor;
+        let (mut legs, mut bond_dims, tensordata) = tensor.into_inner();
         let mut data = tensordata.into_data();
 
         // Find the permutation
@@ -108,12 +102,7 @@ impl Permutor {
         perm.apply_slice_in_place(&mut bond_dims);
         data = data.permuted_axes(perm.to_vec());
 
-        Tensor {
-            tensors: vec![],
-            legs,
-            bond_dims,
-            tensordata: TensorData::Matrix(data),
-        }
+        LeafTensor::new_with_data(legs, bond_dims, TensorData::Matrix(data))
     }
 
     /// Returns whether the permutor is identity, in which case it won't have any
@@ -140,8 +129,8 @@ pub struct Circuit {
     open_edges: Vec<EdgeIndex>,
     /// The next edge to be used.
     next_edge: usize,
-    /// The tensors representing the circuit.
-    tensors: Vec<Tensor>,
+    /// The tensor network representing the circuit.
+    tensor_network: CompositeTensor,
 }
 
 impl Circuit {
@@ -188,13 +177,13 @@ impl Circuit {
         let previous_qubits = self.num_qubits();
 
         self.open_edges.reserve(size);
-        self.tensors.reserve(size);
+        self.tensor_network.reserve(size);
         for _ in 0..size {
             let edge = self.new_edge();
             self.open_edges.push(edge);
-            let mut ket0 = Tensor::new_from_const(vec![edge], 2);
+            let mut ket0 = LeafTensor::new_from_const(vec![edge], 2);
             ket0.set_tensor_data(Self::ket0());
-            self.tensors.push(ket0);
+            self.tensor_network.push_tensor(ket0);
         }
 
         QuantumRegister {
@@ -223,11 +212,11 @@ impl Circuit {
         }
 
         // Create the new tensor
-        let mut new_tensor = Tensor::new_from_const(edges, 2);
+        let mut new_tensor = LeafTensor::new_from_const(edges, 2);
         new_tensor.set_tensor_data(gate);
 
         // Push the new tensor to the tensors
-        self.tensors.push(new_tensor);
+        self.tensor_network.push_tensor(new_tensor);
     }
 
     /// Converts the circuit to a tensor network that computes the amplitude for the
@@ -243,11 +232,11 @@ impl Circuit {
     /// natural order, i.e., sorted by increasing qubit number. If the bitstring
     /// contains no wildcards, the final result is a scalar and the permutator can be
     /// ignored.
-    pub fn into_amplitude_network(mut self, bitstring: &str) -> (Tensor, Permutor) {
+    pub fn into_amplitude_network(mut self, bitstring: &str) -> (CompositeTensor, Permutor) {
         assert_eq!(bitstring.len(), self.num_qubits());
 
         // Apply the final bras
-        self.tensors.reserve(bitstring.len());
+        self.tensor_network.reserve(bitstring.len());
         let mut final_legs = Vec::new();
         for (c, e) in bitstring.chars().zip(self.open_edges) {
             let bra = match c {
@@ -259,18 +248,17 @@ impl Circuit {
                 }
                 _ => panic!("Only 0, 1 and * are allowed in bitstring"),
             };
-            let mut tensor = Tensor::new_from_const(vec![e], 2);
+            let mut tensor = LeafTensor::new_from_const(vec![e], 2);
             tensor.set_tensor_data(bra);
-            self.tensors.push(tensor);
+            self.tensor_network.push_tensor(tensor);
         }
 
         // The contraction can re-order the legs depending on the contraction order,
         // so we need to return the order we want the legs to be in at the end, such
         // that the user can transpose the final tensor and has the expected order of
         // elements.
-        let out = Tensor::new_composite(self.tensors);
         let permutor = Permutor::new(final_legs);
-        (out, permutor)
+        (self.tensor_network, permutor)
     }
 
     /// Converts the circuit to a tensor network that computes the full statevector.
@@ -279,7 +267,7 @@ impl Circuit {
     /// is returned that can transpose the final tensor after contraction to the
     /// natural order, i.e., sorted by increasing qubit number.
     #[inline]
-    pub fn into_statevector_network(self) -> (Tensor, Permutor) {
+    pub fn into_statevector_network(self) -> (CompositeTensor, Permutor) {
         let qubits = self.num_qubits();
         self.into_amplitude_network(&"*".repeat(qubits))
     }
@@ -287,7 +275,7 @@ impl Circuit {
     /// Creates the adjoint tensor of a given `tensor`. This not only modifies the
     /// data, but also the order of legs and the bond dims vec. The legs of the new
     /// tensor are offset by `leg_offset`.
-    fn tensor_adjoint(tensor: &Tensor, leg_offset: usize) -> Tensor {
+    fn tensor_adjoint(tensor: &LeafTensor, leg_offset: usize) -> LeafTensor {
         // Transpose legs and shape of tensor
         let half = tensor.legs().len() / 2;
         let legs = tensor.legs()[half..]
@@ -305,9 +293,7 @@ impl Circuit {
         let data = tensor.tensor_data().clone();
         let data = data.adjoint();
 
-        let mut adjoint = Tensor::new(legs, bond_dims);
-        adjoint.set_tensor_data(data);
-        adjoint
+        LeafTensor::new_with_data(legs, bond_dims, data)
     }
 
     /// Converts the circuit to a tensor network that computes the expectation value
@@ -315,26 +301,28 @@ impl Circuit {
     ///
     /// The tensor network is roughly twice the size of the circuit, as it needs to
     /// compute the adjoint of the circuit as well.
-    pub fn into_expectation_value_network(mut self) -> Tensor {
+    pub fn into_expectation_value_network(mut self) -> CompositeTensor {
         let offset = self.next_edge;
-        self.tensors.reserve(self.tensors.len() + self.num_qubits());
+        self.tensor_network
+            .reserve(self.tensor_network.len() + self.num_qubits());
 
         // Add the mirrored tensor network
-        let mut adjoint_tensors = Vec::with_capacity(self.tensors.len());
-        for tensor in &self.tensors {
+        let mut adjoint_tensors = Vec::with_capacity(self.tensor_network.len());
+        for tensor in self.tensor_network.tensors() {
+            let tensor = tensor.as_leaf().unwrap();
             let adjoint = Self::tensor_adjoint(tensor, offset);
             adjoint_tensors.push(adjoint);
         }
-        self.tensors.append(&mut adjoint_tensors);
+        self.tensor_network.push_tensors(adjoint_tensors);
 
         // Add the layer of observables
         for e in self.open_edges {
-            let mut t = Tensor::new_from_const(vec![e, e + offset], 2);
+            let mut t = LeafTensor::new_from_const(vec![e, e + offset], 2);
             t.set_tensor_data(Self::z());
-            self.tensors.push(t);
+            self.tensor_network.push_tensor(t);
         }
 
-        Tensor::new_composite(self.tensors)
+        self.tensor_network
     }
 }
 
@@ -353,9 +341,7 @@ mod tests {
             ContractionPathResult, Pathfinder,
         },
         path,
-        tensornetwork::{
-            contraction::contract_tensor_network, tensor::Tensor, tensordata::TensorData,
-        },
+        tensornetwork::{contraction::contract_tensor_network, tensordata::TensorData},
     };
 
     fn test_permutation_between(given: &[usize], target: &[usize]) {
@@ -389,7 +375,7 @@ mod tests {
 
         let result = contract_tensor_network(tensor_network, &path);
 
-        let mut tn_ref = Tensor::default();
+        let mut tn_ref = LeafTensor::default();
         tn_ref.set_tensor_data(TensorData::new_from_data(
             &[],
             vec![Complex64::new(FRAC_1_SQRT_2.powi(qubits as i32), 0.0)],
@@ -419,7 +405,7 @@ mod tests {
 
         let result = contract_tensor_network(tensor_network, &path);
 
-        let mut tn_ref = Tensor::default();
+        let mut tn_ref = LeafTensor::default();
         tn_ref.set_tensor_data(TensorData::new_from_data(
             &[],
             vec![Complex64::new(FRAC_1_SQRT_2 * 0.5, 0.0)],
@@ -458,7 +444,7 @@ mod tests {
         let (tensor_network, permutor) = circuit.into_statevector_network();
         let result = contract_tensor_network(tensor_network, &path![(0, 1)]);
         let result = permutor.apply(result);
-        let mut tn_ref = Tensor::new_from_const(vec![1], 2);
+        let mut tn_ref = LeafTensor::new_from_const(vec![1], 2);
         tn_ref.set_tensor_data(TensorData::new_from_data(
             &[2],
             vec![Complex64::new(1.0, 0.0), Complex64::new(3.0, 0.0)],
@@ -468,7 +454,7 @@ mod tests {
 
     #[test]
     fn permute() {
-        let mut tensor = Tensor::new_from_const(vec![0, 1, 2], 2);
+        let mut tensor = LeafTensor::new_from_const(vec![0, 1, 2], 2);
         let data = (0..8).map(|i| Complex64::new(i as f64, 0.0)).collect();
         tensor.set_tensor_data(TensorData::new_from_data(&[2, 2, 2], data));
 
@@ -479,7 +465,7 @@ mod tests {
             .into_iter()
             .map(|i| Complex64::new(i as f64, 0.0))
             .collect();
-        let mut expected = Tensor::new_from_const(vec![2, 0, 1], 2);
+        let mut expected = LeafTensor::new_from_const(vec![2, 0, 1], 2);
         expected.set_tensor_data(TensorData::new_from_data(&[2, 2, 2], ref_data));
 
         assert_abs_diff_eq!(&permuted, &expected);

--- a/tnc/src/builders/peps.rs
+++ b/tnc/src/builders/peps.rs
@@ -1,6 +1,6 @@
 use itertools::iproduct;
 
-use crate::tensornetwork::tensor::Tensor;
+use crate::tensornetwork::tensor::{CompositeTensor, LeafTensor};
 
 /// Generate the initial state for an `length` x `depth` PEPS.
 ///
@@ -11,23 +11,21 @@ use crate::tensornetwork::tensor::Tensor;
 /// * `virtual_dim` - virtual bond dimension between lattice sites in the PEPs
 ///
 /// # Returns
-/// [`Tensor`] of initial state of PEPS
-fn peps_init(length: usize, depth: usize, physical_dim: u64, virtual_dim: u64) -> Tensor {
-    let mut pep = Tensor::default();
-
+/// [`CompositeTensor`] of initial state of PEPS
+fn peps_init(length: usize, depth: usize, physical_dim: u64, virtual_dim: u64) -> CompositeTensor {
     let physical_up = length * depth;
     let virtual_vertical = (length - 1) * depth;
     let virtual_horizontal = (depth - 1) * length;
     let total_edges = physical_up + virtual_vertical + virtual_horizontal;
 
-    let mut tensors = vec![Tensor::default(); length * depth];
+    let mut tensors = vec![LeafTensor::default(); length * depth];
 
     // Consider the corners
-    tensors[0] = Tensor::new(
+    tensors[0] = LeafTensor::new(
         vec![0, physical_up, physical_up + virtual_vertical],
         vec![physical_dim, virtual_dim, virtual_dim],
     );
-    tensors[length - 1] = Tensor::new(
+    tensors[length - 1] = LeafTensor::new(
         vec![
             length - 1,
             physical_up + length - 2,
@@ -35,7 +33,7 @@ fn peps_init(length: usize, depth: usize, physical_dim: u64, virtual_dim: u64) -
         ],
         vec![physical_dim, virtual_dim, virtual_dim],
     );
-    tensors[length * (depth - 1)] = Tensor::new(
+    tensors[length * (depth - 1)] = LeafTensor::new(
         vec![
             length * (depth - 1),
             physical_up + (length - 1) * (depth - 1),
@@ -43,7 +41,7 @@ fn peps_init(length: usize, depth: usize, physical_dim: u64, virtual_dim: u64) -
         ],
         vec![physical_dim, virtual_dim, virtual_dim],
     );
-    tensors[length * depth - 1] = Tensor::new(
+    tensors[length * depth - 1] = LeafTensor::new(
         vec![
             length * depth - 1,
             physical_up + (length - 1) * depth - 1,
@@ -54,7 +52,7 @@ fn peps_init(length: usize, depth: usize, physical_dim: u64, virtual_dim: u64) -
 
     // Consider the horizontal edges
     for j in 1..(length - 1) {
-        tensors[j] = Tensor::new(
+        tensors[j] = LeafTensor::new(
             vec![
                 j,
                 physical_up + j - 1,
@@ -64,7 +62,7 @@ fn peps_init(length: usize, depth: usize, physical_dim: u64, virtual_dim: u64) -
             vec![physical_dim, virtual_dim, virtual_dim, virtual_dim],
         );
 
-        tensors[physical_up - j - 1] = Tensor::new(
+        tensors[physical_up - j - 1] = LeafTensor::new(
             vec![
                 physical_up - j - 1,
                 physical_up + virtual_vertical - j - 1,
@@ -77,7 +75,7 @@ fn peps_init(length: usize, depth: usize, physical_dim: u64, virtual_dim: u64) -
 
     // Consider the vertical edges
     for i in 1..(depth - 1) {
-        tensors[i * length] = Tensor::new(
+        tensors[i * length] = LeafTensor::new(
             vec![
                 i * length,
                 physical_up + i * (length - 1),
@@ -87,7 +85,7 @@ fn peps_init(length: usize, depth: usize, physical_dim: u64, virtual_dim: u64) -
             vec![physical_dim, virtual_dim, virtual_dim, virtual_dim],
         );
 
-        tensors[(i + 1) * length - 1] = Tensor::new(
+        tensors[(i + 1) * length - 1] = LeafTensor::new(
             vec![
                 (i + 1) * length - 1,
                 physical_up + (i + 1) * (length - 1) - 1,
@@ -101,7 +99,7 @@ fn peps_init(length: usize, depth: usize, physical_dim: u64, virtual_dim: u64) -
     // Consider the remaining bulk not on the edges
     for (i, j) in iproduct!(1..(depth - 1), 1..(length - 1)) {
         let index = i * length + j;
-        tensors[index] = Tensor::new(
+        tensors[index] = LeafTensor::new(
             vec![
                 index,
                 physical_up + i * (length - 1) + j - 1,
@@ -119,14 +117,13 @@ fn peps_init(length: usize, depth: usize, physical_dim: u64, virtual_dim: u64) -
         );
     }
 
-    pep.push_tensors(tensors);
-    pep
+    CompositeTensor::new(tensors)
 }
 
 /// Generate an intermediate PEP-operator an n x n PEPs with shared bond dimension of `dimension`.
 ///
 /// # Arguments
-/// * `peps` - mutable [`Tensor`] representing initial PEPS and successive PEPOs
+/// * `peps` - [`CompositeTensor`] representing initial PEPS and successive PEPOs
 /// * `length` - length of the PEPS
 /// * `depth` - depth of the PEPS
 /// * `layer` - layer of PEPO to be applied
@@ -134,15 +131,15 @@ fn peps_init(length: usize, depth: usize, physical_dim: u64, virtual_dim: u64) -
 /// * `virtual_dim` - virtual bond dimension between lattice sites in the PEPs
 ///
 /// # Returns
-/// Updated PEPS [`Tensor`] with `layer`th PEPO applied.
+/// Updated PEPS [`CompositeTensor`] with `layer`th PEPO applied.
 fn pepo(
-    mut peps: Tensor,
+    mut peps: CompositeTensor,
     length: usize,
     depth: usize,
     layer: usize,
     physical_dim: u64,
     virtual_dim: u64,
-) -> Tensor {
+) -> CompositeTensor {
     let physical_up = length * depth;
     let virtual_vertical = (length - 1) * depth;
     let virtual_horizontal = (depth - 1) * length;
@@ -150,10 +147,10 @@ fn pepo(
     let last = total_edges * layer;
     let start = total_edges * (layer + 1);
 
-    let mut tensors = vec![Tensor::default(); length * depth];
+    let mut tensors = vec![LeafTensor::default(); length * depth];
 
     // Consider the corners
-    tensors[0] = Tensor::new(
+    tensors[0] = LeafTensor::new(
         vec![
             last,
             start,
@@ -162,7 +159,7 @@ fn pepo(
         ],
         vec![physical_dim, physical_dim, virtual_dim, virtual_dim],
     );
-    tensors[length - 1] = Tensor::new(
+    tensors[length - 1] = LeafTensor::new(
         vec![
             last + length - 1,
             start + length - 1,
@@ -171,7 +168,7 @@ fn pepo(
         ],
         vec![physical_dim, physical_dim, virtual_dim, virtual_dim],
     );
-    tensors[length * (depth - 1)] = Tensor::new(
+    tensors[length * (depth - 1)] = LeafTensor::new(
         vec![
             last + length * (depth - 1),
             start + length * (depth - 1),
@@ -180,7 +177,7 @@ fn pepo(
         ],
         vec![physical_dim, physical_dim, virtual_dim, virtual_dim],
     );
-    tensors[length * depth - 1] = Tensor::new(
+    tensors[length * depth - 1] = LeafTensor::new(
         vec![
             last + length * depth - 1,
             start + length * depth - 1,
@@ -192,7 +189,7 @@ fn pepo(
 
     // Consider the horizontal edges
     for j in 1..(length - 1) {
-        tensors[j] = Tensor::new(
+        tensors[j] = LeafTensor::new(
             vec![
                 last + j,
                 start + j,
@@ -209,7 +206,7 @@ fn pepo(
             ],
         );
 
-        tensors[physical_up - j - 1] = Tensor::new(
+        tensors[physical_up - j - 1] = LeafTensor::new(
             vec![
                 last + physical_up - j - 1,
                 start + physical_up - j - 1,
@@ -229,7 +226,7 @@ fn pepo(
 
     // Consider the vertical edges
     for i in 1..(depth - 1) {
-        tensors[i * length] = Tensor::new(
+        tensors[i * length] = LeafTensor::new(
             vec![
                 last + i * length,
                 start + i * length,
@@ -246,7 +243,7 @@ fn pepo(
             ],
         );
 
-        tensors[(i + 1) * length - 1] = Tensor::new(
+        tensors[(i + 1) * length - 1] = LeafTensor::new(
             vec![
                 last + (i + 1) * length - 1,
                 start + (i + 1) * length - 1,
@@ -267,7 +264,7 @@ fn pepo(
     // Consider the remaining bulk not on the edges
     for (i, j) in iproduct!(1..(depth - 1), 1..(length - 1)) {
         let index = i * length + j;
-        tensors[index] = Tensor::new(
+        tensors[index] = LeafTensor::new(
             vec![
                 last + index,
                 start + index,
@@ -293,22 +290,22 @@ fn pepo(
 /// Applies the final state in a PEPS.
 ///
 /// # Arguments
-/// * `peps` - mutable [`Tensor`] representing initial PEPS and successive PEPOs
+/// * `peps` - [`CompositeTensor`] representing initial PEPS and successive PEPOs
 /// * `length` - length of the PEPS
 /// * `depth` - depth of the PEPS
 /// * `physical_dim` - physical dimension of the PEPs
 /// * `virtual_dim` - virtual bond dimension between lattice sites in the PEPs
 ///
 /// # Returns
-/// Updated PEPS [`Tensor`] with final PEPS applied
+/// Updated PEPS [`CompositeTensor`] with final PEPS applied
 fn peps_final(
-    mut peps: Tensor,
+    mut peps: CompositeTensor,
     length: usize,
     depth: usize,
     physical_dim: u64,
     virtual_dim: u64,
     layers: usize,
-) -> Tensor {
+) -> CompositeTensor {
     let physical_up = length * depth;
     let virtual_vertical = (length - 1) * depth;
     let virtual_horizontal = (depth - 1) * length;
@@ -317,14 +314,14 @@ fn peps_final(
     let start = total_edges * (layers + 1);
     total_edges -= physical_up;
 
-    let mut tensors = vec![Tensor::default(); length * depth];
+    let mut tensors = vec![LeafTensor::default(); length * depth];
 
     // Consider the corners
-    tensors[0] = Tensor::new(
+    tensors[0] = LeafTensor::new(
         vec![last, start, start + virtual_vertical],
         vec![physical_dim, virtual_dim, virtual_dim],
     );
-    tensors[length - 1] = Tensor::new(
+    tensors[length - 1] = LeafTensor::new(
         vec![
             last + length - 1,
             start + length - 2,
@@ -332,7 +329,7 @@ fn peps_final(
         ],
         vec![physical_dim, virtual_dim, virtual_dim],
     );
-    tensors[length * (depth - 1)] = Tensor::new(
+    tensors[length * (depth - 1)] = LeafTensor::new(
         vec![
             last + length * (depth - 1),
             start + (length - 1) * (depth - 1),
@@ -340,7 +337,7 @@ fn peps_final(
         ],
         vec![physical_dim, virtual_dim, virtual_dim],
     );
-    tensors[length * depth - 1] = Tensor::new(
+    tensors[length * depth - 1] = LeafTensor::new(
         vec![
             last + length * depth - 1,
             start + (length - 1) * depth - 1,
@@ -351,7 +348,7 @@ fn peps_final(
 
     // Consider the horizontal edges
     for j in 1..(length - 1) {
-        tensors[j] = Tensor::new(
+        tensors[j] = LeafTensor::new(
             vec![
                 last + j,
                 start + j - 1,
@@ -361,7 +358,7 @@ fn peps_final(
             vec![physical_dim, virtual_dim, virtual_dim, virtual_dim],
         );
 
-        tensors[physical_up - j - 1] = Tensor::new(
+        tensors[physical_up - j - 1] = LeafTensor::new(
             vec![
                 last + physical_up - j - 1,
                 start + virtual_vertical - j - 1,
@@ -374,7 +371,7 @@ fn peps_final(
 
     // Consider the vertical edges
     for i in 1..(depth - 1) {
-        tensors[i * length] = Tensor::new(
+        tensors[i * length] = LeafTensor::new(
             vec![
                 last + i * length,
                 start + i * (length - 1),
@@ -384,7 +381,7 @@ fn peps_final(
             vec![physical_dim, virtual_dim, virtual_dim, virtual_dim],
         );
 
-        tensors[(i + 1) * length - 1] = Tensor::new(
+        tensors[(i + 1) * length - 1] = LeafTensor::new(
             vec![
                 last + (i + 1) * length - 1,
                 start + (i + 1) * (length - 1) - 1,
@@ -398,7 +395,7 @@ fn peps_final(
     // Consider the remaining bulk not on the edges
     for (i, j) in iproduct!(1..(depth - 1), 1..(length - 1)) {
         let index = i * length + j;
-        tensors[index] = Tensor::new(
+        tensors[index] = LeafTensor::new(
             vec![
                 last + index,
                 start + i * (length - 1) + j - 1,
@@ -441,7 +438,7 @@ fn peps_final(
 /// * `layers` - number of operator layers in PEPS, 0 layers returns an inner product of two states.
 ///
 /// # Returns
-/// [`Tensor`] representing a PEPS.
+/// [`CompositeTensor`] representing a PEPS.
 ///
 /// # Panics
 /// Panics if `length < 2` or `depth < 2`.
@@ -452,7 +449,7 @@ pub fn peps(
     physical_dim: u64,
     virtual_dim: u64,
     layers: usize,
-) -> Tensor {
+) -> CompositeTensor {
     assert!(length > 1, "PEPS should have length greater than 1");
     assert!(depth > 1, "PEPS should have depth greater than 1");
     let mut new_peps = peps_init(length, depth, physical_dim, virtual_dim);
@@ -469,8 +466,6 @@ mod tests {
     use std::iter::zip;
 
     use rustc_hash::FxHashMap;
-
-    use crate::tensornetwork::tensor::Tensor;
 
     #[test]
     fn test_pep_init() {
@@ -503,20 +498,22 @@ mod tests {
             (20, 10),
         ]);
         let tensors = vec![
-            Tensor::new_from_map(vec![0, 9, 15], &bond_dims),
-            Tensor::new_from_map(vec![1, 9, 10, 16], &bond_dims),
-            Tensor::new_from_map(vec![2, 10, 17], &bond_dims),
-            Tensor::new_from_map(vec![3, 11, 15, 18], &bond_dims),
-            Tensor::new_from_map(vec![4, 11, 12, 16, 19], &bond_dims),
-            Tensor::new_from_map(vec![5, 12, 17, 20], &bond_dims),
-            Tensor::new_from_map(vec![6, 13, 18], &bond_dims),
-            Tensor::new_from_map(vec![7, 13, 14, 19], &bond_dims),
-            Tensor::new_from_map(vec![8, 14, 20], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 9, 15], &bond_dims),
+            LeafTensor::new_from_map(vec![1, 9, 10, 16], &bond_dims),
+            LeafTensor::new_from_map(vec![2, 10, 17], &bond_dims),
+            LeafTensor::new_from_map(vec![3, 11, 15, 18], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 11, 12, 16, 19], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 12, 17, 20], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 13, 18], &bond_dims),
+            LeafTensor::new_from_map(vec![7, 13, 14, 19], &bond_dims),
+            LeafTensor::new_from_map(vec![8, 14, 20], &bond_dims),
         ];
-        let ref_tensor = Tensor::new_composite(tensors);
+        let ref_tensor = CompositeTensor::new(tensors);
 
         let new_peps = peps_init(length, depth, physical_dim, virtual_dim);
         for (t1, t2) in zip(new_peps.tensors().iter(), ref_tensor.tensors().iter()) {
+            let t1 = t1.as_leaf().unwrap();
+            let t2 = t2.as_leaf().unwrap();
             assert_eq!(t1.legs(), t2.legs());
             assert_eq!(t1.bond_dims(), t2.bond_dims());
         }
@@ -575,26 +572,26 @@ mod tests {
             (41, 10),
         ]);
         let tensors = vec![
-            Tensor::new_from_map(vec![0, 9, 15], &bond_dims),
-            Tensor::new_from_map(vec![1, 9, 10, 16], &bond_dims),
-            Tensor::new_from_map(vec![2, 10, 17], &bond_dims),
-            Tensor::new_from_map(vec![3, 11, 15, 18], &bond_dims),
-            Tensor::new_from_map(vec![4, 11, 12, 16, 19], &bond_dims),
-            Tensor::new_from_map(vec![5, 12, 17, 20], &bond_dims),
-            Tensor::new_from_map(vec![6, 13, 18], &bond_dims),
-            Tensor::new_from_map(vec![7, 13, 14, 19], &bond_dims),
-            Tensor::new_from_map(vec![8, 14, 20], &bond_dims),
-            Tensor::new_from_map(vec![0, 21, 30, 36], &bond_dims),
-            Tensor::new_from_map(vec![1, 22, 30, 31, 37], &bond_dims),
-            Tensor::new_from_map(vec![2, 23, 31, 38], &bond_dims),
-            Tensor::new_from_map(vec![3, 24, 32, 36, 39], &bond_dims),
-            Tensor::new_from_map(vec![4, 25, 32, 33, 37, 40], &bond_dims),
-            Tensor::new_from_map(vec![5, 26, 33, 38, 41], &bond_dims),
-            Tensor::new_from_map(vec![6, 27, 34, 39], &bond_dims),
-            Tensor::new_from_map(vec![7, 28, 34, 35, 40], &bond_dims),
-            Tensor::new_from_map(vec![8, 29, 35, 41], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 9, 15], &bond_dims),
+            LeafTensor::new_from_map(vec![1, 9, 10, 16], &bond_dims),
+            LeafTensor::new_from_map(vec![2, 10, 17], &bond_dims),
+            LeafTensor::new_from_map(vec![3, 11, 15, 18], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 11, 12, 16, 19], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 12, 17, 20], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 13, 18], &bond_dims),
+            LeafTensor::new_from_map(vec![7, 13, 14, 19], &bond_dims),
+            LeafTensor::new_from_map(vec![8, 14, 20], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 21, 30, 36], &bond_dims),
+            LeafTensor::new_from_map(vec![1, 22, 30, 31, 37], &bond_dims),
+            LeafTensor::new_from_map(vec![2, 23, 31, 38], &bond_dims),
+            LeafTensor::new_from_map(vec![3, 24, 32, 36, 39], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 25, 32, 33, 37, 40], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 26, 33, 38, 41], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 27, 34, 39], &bond_dims),
+            LeafTensor::new_from_map(vec![7, 28, 34, 35, 40], &bond_dims),
+            LeafTensor::new_from_map(vec![8, 29, 35, 41], &bond_dims),
         ];
-        let ref_tensor = Tensor::new_composite(tensors);
+        let ref_tensor = CompositeTensor::new(tensors);
 
         let mut new_peps = peps_init(length, depth, physical_dim, virtual_dim);
         for layer in 0..layers {
@@ -602,6 +599,8 @@ mod tests {
         }
 
         for (t1, t2) in zip(new_peps.tensors().iter(), ref_tensor.tensors().iter()) {
+            let t1 = t1.as_leaf().unwrap();
+            let t2 = t2.as_leaf().unwrap();
             assert_eq!(t1.legs(), t2.legs());
             assert_eq!(t1.bond_dims(), t2.bond_dims());
         }
@@ -672,35 +671,35 @@ mod tests {
             (53, 10),
         ]);
         let tensors = vec![
-            Tensor::new_from_map(vec![0, 9, 15], &bond_dims),
-            Tensor::new_from_map(vec![1, 9, 10, 16], &bond_dims),
-            Tensor::new_from_map(vec![2, 10, 17], &bond_dims),
-            Tensor::new_from_map(vec![3, 11, 15, 18], &bond_dims),
-            Tensor::new_from_map(vec![4, 11, 12, 16, 19], &bond_dims),
-            Tensor::new_from_map(vec![5, 12, 17, 20], &bond_dims),
-            Tensor::new_from_map(vec![6, 13, 18], &bond_dims),
-            Tensor::new_from_map(vec![7, 13, 14, 19], &bond_dims),
-            Tensor::new_from_map(vec![8, 14, 20], &bond_dims),
-            Tensor::new_from_map(vec![0, 21, 30, 36], &bond_dims),
-            Tensor::new_from_map(vec![1, 22, 30, 31, 37], &bond_dims),
-            Tensor::new_from_map(vec![2, 23, 31, 38], &bond_dims),
-            Tensor::new_from_map(vec![3, 24, 32, 36, 39], &bond_dims),
-            Tensor::new_from_map(vec![4, 25, 32, 33, 37, 40], &bond_dims),
-            Tensor::new_from_map(vec![5, 26, 33, 38, 41], &bond_dims),
-            Tensor::new_from_map(vec![6, 27, 34, 39], &bond_dims),
-            Tensor::new_from_map(vec![7, 28, 34, 35, 40], &bond_dims),
-            Tensor::new_from_map(vec![8, 29, 35, 41], &bond_dims),
-            Tensor::new_from_map(vec![21, 42, 48], &bond_dims),
-            Tensor::new_from_map(vec![22, 42, 43, 49], &bond_dims),
-            Tensor::new_from_map(vec![23, 43, 50], &bond_dims),
-            Tensor::new_from_map(vec![24, 44, 48, 51], &bond_dims),
-            Tensor::new_from_map(vec![25, 44, 45, 49, 52], &bond_dims),
-            Tensor::new_from_map(vec![26, 45, 50, 53], &bond_dims),
-            Tensor::new_from_map(vec![27, 46, 51], &bond_dims),
-            Tensor::new_from_map(vec![28, 46, 47, 52], &bond_dims),
-            Tensor::new_from_map(vec![29, 47, 53], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 9, 15], &bond_dims),
+            LeafTensor::new_from_map(vec![1, 9, 10, 16], &bond_dims),
+            LeafTensor::new_from_map(vec![2, 10, 17], &bond_dims),
+            LeafTensor::new_from_map(vec![3, 11, 15, 18], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 11, 12, 16, 19], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 12, 17, 20], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 13, 18], &bond_dims),
+            LeafTensor::new_from_map(vec![7, 13, 14, 19], &bond_dims),
+            LeafTensor::new_from_map(vec![8, 14, 20], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 21, 30, 36], &bond_dims),
+            LeafTensor::new_from_map(vec![1, 22, 30, 31, 37], &bond_dims),
+            LeafTensor::new_from_map(vec![2, 23, 31, 38], &bond_dims),
+            LeafTensor::new_from_map(vec![3, 24, 32, 36, 39], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 25, 32, 33, 37, 40], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 26, 33, 38, 41], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 27, 34, 39], &bond_dims),
+            LeafTensor::new_from_map(vec![7, 28, 34, 35, 40], &bond_dims),
+            LeafTensor::new_from_map(vec![8, 29, 35, 41], &bond_dims),
+            LeafTensor::new_from_map(vec![21, 42, 48], &bond_dims),
+            LeafTensor::new_from_map(vec![22, 42, 43, 49], &bond_dims),
+            LeafTensor::new_from_map(vec![23, 43, 50], &bond_dims),
+            LeafTensor::new_from_map(vec![24, 44, 48, 51], &bond_dims),
+            LeafTensor::new_from_map(vec![25, 44, 45, 49, 52], &bond_dims),
+            LeafTensor::new_from_map(vec![26, 45, 50, 53], &bond_dims),
+            LeafTensor::new_from_map(vec![27, 46, 51], &bond_dims),
+            LeafTensor::new_from_map(vec![28, 46, 47, 52], &bond_dims),
+            LeafTensor::new_from_map(vec![29, 47, 53], &bond_dims),
         ];
-        let ref_tensor = Tensor::new_composite(tensors);
+        let ref_tensor = CompositeTensor::new(tensors);
 
         let mut new_peps = peps_init(length, depth, physical_dim, virtual_dim);
         for layer in 0..layers {
@@ -708,6 +707,8 @@ mod tests {
         }
         let new_peps = peps_final(new_peps, length, depth, physical_dim, virtual_dim, layers);
         for (t1, t2) in zip(new_peps.tensors().iter(), ref_tensor.tensors().iter()) {
+            let t1 = t1.as_leaf().unwrap();
+            let t2 = t2.as_leaf().unwrap();
             assert_eq!(t1.legs(), t2.legs());
             assert_eq!(t1.bond_dims(), t2.bond_dims());
         }
@@ -778,38 +779,40 @@ mod tests {
             (53, 10),
         ]);
         let tensors = vec![
-            Tensor::new_from_map(vec![0, 9, 15], &bond_dims),
-            Tensor::new_from_map(vec![1, 9, 10, 16], &bond_dims),
-            Tensor::new_from_map(vec![2, 10, 17], &bond_dims),
-            Tensor::new_from_map(vec![3, 11, 15, 18], &bond_dims),
-            Tensor::new_from_map(vec![4, 11, 12, 16, 19], &bond_dims),
-            Tensor::new_from_map(vec![5, 12, 17, 20], &bond_dims),
-            Tensor::new_from_map(vec![6, 13, 18], &bond_dims),
-            Tensor::new_from_map(vec![7, 13, 14, 19], &bond_dims),
-            Tensor::new_from_map(vec![8, 14, 20], &bond_dims),
-            Tensor::new_from_map(vec![0, 21, 30, 36], &bond_dims),
-            Tensor::new_from_map(vec![1, 22, 30, 31, 37], &bond_dims),
-            Tensor::new_from_map(vec![2, 23, 31, 38], &bond_dims),
-            Tensor::new_from_map(vec![3, 24, 32, 36, 39], &bond_dims),
-            Tensor::new_from_map(vec![4, 25, 32, 33, 37, 40], &bond_dims),
-            Tensor::new_from_map(vec![5, 26, 33, 38, 41], &bond_dims),
-            Tensor::new_from_map(vec![6, 27, 34, 39], &bond_dims),
-            Tensor::new_from_map(vec![7, 28, 34, 35, 40], &bond_dims),
-            Tensor::new_from_map(vec![8, 29, 35, 41], &bond_dims),
-            Tensor::new_from_map(vec![21, 42, 48], &bond_dims),
-            Tensor::new_from_map(vec![22, 42, 43, 49], &bond_dims),
-            Tensor::new_from_map(vec![23, 43, 50], &bond_dims),
-            Tensor::new_from_map(vec![24, 44, 48, 51], &bond_dims),
-            Tensor::new_from_map(vec![25, 44, 45, 49, 52], &bond_dims),
-            Tensor::new_from_map(vec![26, 45, 50, 53], &bond_dims),
-            Tensor::new_from_map(vec![27, 46, 51], &bond_dims),
-            Tensor::new_from_map(vec![28, 46, 47, 52], &bond_dims),
-            Tensor::new_from_map(vec![29, 47, 53], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 9, 15], &bond_dims),
+            LeafTensor::new_from_map(vec![1, 9, 10, 16], &bond_dims),
+            LeafTensor::new_from_map(vec![2, 10, 17], &bond_dims),
+            LeafTensor::new_from_map(vec![3, 11, 15, 18], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 11, 12, 16, 19], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 12, 17, 20], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 13, 18], &bond_dims),
+            LeafTensor::new_from_map(vec![7, 13, 14, 19], &bond_dims),
+            LeafTensor::new_from_map(vec![8, 14, 20], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 21, 30, 36], &bond_dims),
+            LeafTensor::new_from_map(vec![1, 22, 30, 31, 37], &bond_dims),
+            LeafTensor::new_from_map(vec![2, 23, 31, 38], &bond_dims),
+            LeafTensor::new_from_map(vec![3, 24, 32, 36, 39], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 25, 32, 33, 37, 40], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 26, 33, 38, 41], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 27, 34, 39], &bond_dims),
+            LeafTensor::new_from_map(vec![7, 28, 34, 35, 40], &bond_dims),
+            LeafTensor::new_from_map(vec![8, 29, 35, 41], &bond_dims),
+            LeafTensor::new_from_map(vec![21, 42, 48], &bond_dims),
+            LeafTensor::new_from_map(vec![22, 42, 43, 49], &bond_dims),
+            LeafTensor::new_from_map(vec![23, 43, 50], &bond_dims),
+            LeafTensor::new_from_map(vec![24, 44, 48, 51], &bond_dims),
+            LeafTensor::new_from_map(vec![25, 44, 45, 49, 52], &bond_dims),
+            LeafTensor::new_from_map(vec![26, 45, 50, 53], &bond_dims),
+            LeafTensor::new_from_map(vec![27, 46, 51], &bond_dims),
+            LeafTensor::new_from_map(vec![28, 46, 47, 52], &bond_dims),
+            LeafTensor::new_from_map(vec![29, 47, 53], &bond_dims),
         ];
-        let ref_tensor = Tensor::new_composite(tensors);
+        let ref_tensor = CompositeTensor::new(tensors);
 
         let new_peps = peps(length, depth, physical_dim, virtual_dim, layers);
         for (t1, t2) in zip(new_peps.tensors().iter(), ref_tensor.tensors().iter()) {
+            let t1 = t1.as_leaf().unwrap();
+            let t2 = t2.as_leaf().unwrap();
             assert_eq!(t1.legs(), t2.legs());
             assert_eq!(t1.bond_dims(), t2.bond_dims());
         }
@@ -838,16 +841,16 @@ mod tests {
             (11, 10),
         ]);
         let tensors = vec![
-            Tensor::new_from_map(vec![0, 4, 6], &bond_dims),
-            Tensor::new_from_map(vec![1, 4, 7], &bond_dims),
-            Tensor::new_from_map(vec![2, 5, 6], &bond_dims),
-            Tensor::new_from_map(vec![3, 5, 7], &bond_dims),
-            Tensor::new_from_map(vec![0, 8, 10], &bond_dims),
-            Tensor::new_from_map(vec![1, 8, 11], &bond_dims),
-            Tensor::new_from_map(vec![2, 9, 10], &bond_dims),
-            Tensor::new_from_map(vec![3, 9, 11], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 4, 6], &bond_dims),
+            LeafTensor::new_from_map(vec![1, 4, 7], &bond_dims),
+            LeafTensor::new_from_map(vec![2, 5, 6], &bond_dims),
+            LeafTensor::new_from_map(vec![3, 5, 7], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 8, 10], &bond_dims),
+            LeafTensor::new_from_map(vec![1, 8, 11], &bond_dims),
+            LeafTensor::new_from_map(vec![2, 9, 10], &bond_dims),
+            LeafTensor::new_from_map(vec![3, 9, 11], &bond_dims),
         ];
-        let ref_tensor = Tensor::new_composite(tensors);
+        let ref_tensor = CompositeTensor::new(tensors);
 
         let mut new_peps = peps_init(length, depth, physical_dim, virtual_dim);
         for layer in 0..layers {
@@ -855,6 +858,8 @@ mod tests {
         }
         let new_peps = peps_final(new_peps, length, depth, physical_dim, virtual_dim, layers);
         for (t1, t2) in zip(new_peps.tensors().iter(), ref_tensor.tensors().iter()) {
+            let t1 = t1.as_leaf().unwrap();
+            let t2 = t2.as_leaf().unwrap();
             assert_eq!(t1.legs(), t2.legs());
             assert_eq!(t1.bond_dims(), t2.bond_dims());
         }
@@ -871,13 +876,15 @@ mod tests {
 
         let bond_dims = FxHashMap::from_iter([(0, 4), (1, 4), (2, 10)]);
         let tensors = vec![
-            Tensor::new_from_map(vec![0, 2], &bond_dims),
-            Tensor::new_from_map(vec![1, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![1, 2], &bond_dims),
         ];
-        let ref_tensor = Tensor::new_composite(tensors);
+        let ref_tensor = CompositeTensor::new(tensors);
 
         let new_peps = peps(length, depth, physical_dim, virtual_dim, layers);
         for (t1, t2) in zip(new_peps.tensors().iter(), ref_tensor.tensors().iter()) {
+            let t1 = t1.as_leaf().unwrap();
+            let t2 = t2.as_leaf().unwrap();
             assert_eq!(t1.legs(), t2.legs());
             assert_eq!(t1.bond_dims(), t2.bond_dims());
         }

--- a/tnc/src/builders/random_circuit.rs
+++ b/tnc/src/builders/random_circuit.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashMap;
 use crate::builders::circuit_builder::Circuit;
 use crate::builders::connectivity::{Connectivity, ConnectivityLayout};
 use crate::builders::tensorgeneration::random_sparse_tensor_data_with_rng;
-use crate::tensornetwork::tensor::Tensor;
+use crate::tensornetwork::tensor::{CompositeTensor, LeafTensor};
 use crate::tensornetwork::tensordata::TensorData;
 use crate::utils::traits::WithCapacity;
 
@@ -33,7 +33,7 @@ pub fn random_circuit<R>(
     two_qubit_probability: f64,
     rng: &mut R,
     connectivity: ConnectivityLayout,
-) -> Tensor
+) -> CompositeTensor
 where
     R: Rng,
 {
@@ -93,7 +93,7 @@ pub fn random_circuit_with_observable<R>(
     observable_probability: f64,
     rng: &mut R,
     connectivity: ConnectivityLayout,
-) -> Tensor
+) -> CompositeTensor
 where
     R: Rng,
 {
@@ -125,7 +125,7 @@ pub fn random_circuit_with_set_observable<R>(
     observable_location: &[usize],
     rng: &mut R,
     connectivity: ConnectivityLayout,
-) -> Tensor
+) -> CompositeTensor
 where
     R: Rng,
 {
@@ -154,7 +154,7 @@ where
     let two_qubit_die = Bernoulli::new(two_qubit_probability).unwrap();
 
     // Initialize tensornetwork of size `usize`
-    let mut random_tn = Tensor::default();
+    let mut random_tn = CompositeTensor::default();
 
     let mut open_edges = FxHashMap::with_capacity(qubits);
 
@@ -169,7 +169,7 @@ where
 
             let new_observable = observables.choose(rng).unwrap().clone();
             let mut new_tensor =
-                Tensor::new_from_const(vec![open_edges[&i].0, open_edges[&i].1], 2);
+                LeafTensor::new_from_const(vec![open_edges[&i].0, open_edges[&i].1], 2);
             new_tensor.set_tensor_data(new_observable);
             final_state.push(new_tensor);
         } else {
@@ -209,14 +209,14 @@ where
                     (next_edge - 1, next_edge - 1)
                 };
 
-                let mut left_new_tensor = Tensor::new_from_const(
+                let mut left_new_tensor = LeafTensor::new_from_const(
                     vec![next_edge, next_edge + 1, left_i_index, left_j_index],
                     2,
                 );
                 left_new_tensor.set_tensor_data(fsim!(0.3, 0.2, false));
                 intermediate_gates.push(left_new_tensor);
 
-                let mut right_new_tensor = Tensor::new_from_const(
+                let mut right_new_tensor = LeafTensor::new_from_const(
                     vec![right_i_index, right_j_index, next_edge + 2, next_edge + 3],
                     2,
                 );
@@ -237,12 +237,13 @@ where
                 let (left_new_gate, right_new_gate) =
                     single_qubit_gates.choose(rng).unwrap().clone();
 
-                let mut left_new_tensor = Tensor::new_from_const(vec![next_edge, left_index], 2);
+                let mut left_new_tensor =
+                    LeafTensor::new_from_const(vec![next_edge, left_index], 2);
                 left_new_tensor.set_tensor_data(left_new_gate);
                 intermediate_gates.push(left_new_tensor);
 
                 let mut right_new_tensor =
-                    Tensor::new_from_const(vec![right_index, next_edge + 1], 2);
+                    LeafTensor::new_from_const(vec![right_index, next_edge + 1], 2);
                 right_new_tensor.set_tensor_data(right_new_gate);
                 intermediate_gates.push(right_new_tensor);
 
@@ -260,17 +261,16 @@ where
         if left_index != right_index {
             let random_sparse_tensor = random_sparse_tensor_data_with_rng(&[2], Some(1f32), rng);
 
-            let mut left_new_state = Tensor::new_from_const(vec![left_index], 2);
+            let mut left_new_state = LeafTensor::new_from_const(vec![left_index], 2);
             left_new_state.set_tensor_data(random_sparse_tensor.clone());
             initial_state.push(left_new_state);
 
-            let mut right_new_state = Tensor::new_from_const(vec![right_index], 2);
+            let mut right_new_state = LeafTensor::new_from_const(vec![right_index], 2);
             right_new_state.set_tensor_data(random_sparse_tensor);
             initial_state.push(right_new_state);
         }
     }
     random_tn.push_tensors(initial_state);
-
     random_tn
 }
 
@@ -283,7 +283,6 @@ mod tests {
     use rand::rng;
 
     use crate::builders::connectivity::ConnectivityLayout;
-    use crate::tensornetwork::tensor::Tensor;
 
     #[test]
     fn test_random_circuit_with_observable() {
@@ -305,50 +304,51 @@ mod tests {
             connectivity,
         );
         let ref_legs = [
-            Tensor::new_from_const(vec![0, 1], 2),
-            Tensor::new_from_const(vec![2, 3], 2),
-            Tensor::new_from_const(vec![4, 5], 2),
-            Tensor::new_from_const(vec![6, 7], 2),
-            Tensor::new_from_const(vec![8, 9, 0, 2], 2),
-            Tensor::new_from_const(vec![1, 3, 10, 11], 2),
-            Tensor::new_from_const(vec![12, 13, 9, 4], 2),
-            Tensor::new_from_const(vec![11, 5, 14, 15], 2),
-            Tensor::new_from_const(vec![16, 17, 13, 6], 2),
-            Tensor::new_from_const(vec![15, 7, 18, 19], 2),
-            Tensor::new_from_const(vec![20, 8], 2),
-            Tensor::new_from_const(vec![10, 21], 2),
-            Tensor::new_from_const(vec![22, 12], 2),
-            Tensor::new_from_const(vec![14, 23], 2),
-            Tensor::new_from_const(vec![24, 16], 2),
-            Tensor::new_from_const(vec![18, 25], 2),
-            Tensor::new_from_const(vec![26, 17], 2),
-            Tensor::new_from_const(vec![19, 27], 2),
-            Tensor::new_from_const(vec![28, 29, 20, 22], 2),
-            Tensor::new_from_const(vec![21, 23, 30, 31], 2),
-            Tensor::new_from_const(vec![32, 33, 29, 24], 2),
-            Tensor::new_from_const(vec![31, 25, 34, 35], 2),
-            Tensor::new_from_const(vec![36, 37, 33, 26], 2),
-            Tensor::new_from_const(vec![35, 27, 38, 39], 2),
-            Tensor::new_from_const(vec![40, 28], 2),
-            Tensor::new_from_const(vec![30, 41], 2),
-            Tensor::new_from_const(vec![42, 32], 2),
-            Tensor::new_from_const(vec![34, 43], 2),
-            Tensor::new_from_const(vec![44, 36], 2),
-            Tensor::new_from_const(vec![38, 45], 2),
-            Tensor::new_from_const(vec![46, 37], 2),
-            Tensor::new_from_const(vec![39, 47], 2),
-            Tensor::new_from_const(vec![40], 2),
-            Tensor::new_from_const(vec![41], 2),
-            Tensor::new_from_const(vec![42], 2),
-            Tensor::new_from_const(vec![43], 2),
-            Tensor::new_from_const(vec![44], 2),
-            Tensor::new_from_const(vec![45], 2),
-            Tensor::new_from_const(vec![46], 2),
-            Tensor::new_from_const(vec![47], 2),
+            LeafTensor::new_from_const(vec![0, 1], 2),
+            LeafTensor::new_from_const(vec![2, 3], 2),
+            LeafTensor::new_from_const(vec![4, 5], 2),
+            LeafTensor::new_from_const(vec![6, 7], 2),
+            LeafTensor::new_from_const(vec![8, 9, 0, 2], 2),
+            LeafTensor::new_from_const(vec![1, 3, 10, 11], 2),
+            LeafTensor::new_from_const(vec![12, 13, 9, 4], 2),
+            LeafTensor::new_from_const(vec![11, 5, 14, 15], 2),
+            LeafTensor::new_from_const(vec![16, 17, 13, 6], 2),
+            LeafTensor::new_from_const(vec![15, 7, 18, 19], 2),
+            LeafTensor::new_from_const(vec![20, 8], 2),
+            LeafTensor::new_from_const(vec![10, 21], 2),
+            LeafTensor::new_from_const(vec![22, 12], 2),
+            LeafTensor::new_from_const(vec![14, 23], 2),
+            LeafTensor::new_from_const(vec![24, 16], 2),
+            LeafTensor::new_from_const(vec![18, 25], 2),
+            LeafTensor::new_from_const(vec![26, 17], 2),
+            LeafTensor::new_from_const(vec![19, 27], 2),
+            LeafTensor::new_from_const(vec![28, 29, 20, 22], 2),
+            LeafTensor::new_from_const(vec![21, 23, 30, 31], 2),
+            LeafTensor::new_from_const(vec![32, 33, 29, 24], 2),
+            LeafTensor::new_from_const(vec![31, 25, 34, 35], 2),
+            LeafTensor::new_from_const(vec![36, 37, 33, 26], 2),
+            LeafTensor::new_from_const(vec![35, 27, 38, 39], 2),
+            LeafTensor::new_from_const(vec![40, 28], 2),
+            LeafTensor::new_from_const(vec![30, 41], 2),
+            LeafTensor::new_from_const(vec![42, 32], 2),
+            LeafTensor::new_from_const(vec![34, 43], 2),
+            LeafTensor::new_from_const(vec![44, 36], 2),
+            LeafTensor::new_from_const(vec![38, 45], 2),
+            LeafTensor::new_from_const(vec![46, 37], 2),
+            LeafTensor::new_from_const(vec![39, 47], 2),
+            LeafTensor::new_from_const(vec![40], 2),
+            LeafTensor::new_from_const(vec![41], 2),
+            LeafTensor::new_from_const(vec![42], 2),
+            LeafTensor::new_from_const(vec![43], 2),
+            LeafTensor::new_from_const(vec![44], 2),
+            LeafTensor::new_from_const(vec![45], 2),
+            LeafTensor::new_from_const(vec![46], 2),
+            LeafTensor::new_from_const(vec![47], 2),
         ];
 
         assert_eq!(circuit.tensors().len(), 40);
         for (tensor, ref_tensor) in zip(circuit.tensors(), ref_legs) {
+            let tensor = tensor.as_leaf().unwrap();
             assert_eq!(tensor.legs(), ref_tensor.legs());
             assert_eq!(tensor.bond_dims(), ref_tensor.bond_dims());
         }
@@ -374,43 +374,44 @@ mod tests {
             connectivity,
         );
         let ref_legs = [
-            Tensor::new_from_const(vec![0, 1], 2),
-            Tensor::new_from_const(vec![3, 4, 2, 0], 2),
-            Tensor::new_from_const(vec![2, 1, 5, 6], 2),
-            Tensor::new_from_const(vec![8, 9, 4, 7], 2),
-            Tensor::new_from_const(vec![6, 7, 10, 11], 2),
-            Tensor::new_from_const(vec![12, 3], 2),
-            Tensor::new_from_const(vec![5, 13], 2),
-            Tensor::new_from_const(vec![14, 8], 2),
-            Tensor::new_from_const(vec![10, 15], 2),
-            Tensor::new_from_const(vec![16, 9], 2),
-            Tensor::new_from_const(vec![11, 17], 2),
-            Tensor::new_from_const(vec![19, 20, 18, 12], 2),
-            Tensor::new_from_const(vec![18, 13, 21, 22], 2),
-            Tensor::new_from_const(vec![23, 24, 20, 14], 2),
-            Tensor::new_from_const(vec![22, 15, 25, 26], 2),
-            Tensor::new_from_const(vec![27, 28, 24, 16], 2),
-            Tensor::new_from_const(vec![26, 17, 29, 30], 2),
-            Tensor::new_from_const(vec![31, 19], 2),
-            Tensor::new_from_const(vec![21, 32], 2),
-            Tensor::new_from_const(vec![33, 23], 2),
-            Tensor::new_from_const(vec![25, 34], 2),
-            Tensor::new_from_const(vec![35, 27], 2),
-            Tensor::new_from_const(vec![29, 36], 2),
-            Tensor::new_from_const(vec![37, 28], 2),
-            Tensor::new_from_const(vec![30, 38], 2),
-            Tensor::new_from_const(vec![31], 2),
-            Tensor::new_from_const(vec![32], 2),
-            Tensor::new_from_const(vec![33], 2),
-            Tensor::new_from_const(vec![34], 2),
-            Tensor::new_from_const(vec![35], 2),
-            Tensor::new_from_const(vec![36], 2),
-            Tensor::new_from_const(vec![37], 2),
-            Tensor::new_from_const(vec![38], 2),
+            LeafTensor::new_from_const(vec![0, 1], 2),
+            LeafTensor::new_from_const(vec![3, 4, 2, 0], 2),
+            LeafTensor::new_from_const(vec![2, 1, 5, 6], 2),
+            LeafTensor::new_from_const(vec![8, 9, 4, 7], 2),
+            LeafTensor::new_from_const(vec![6, 7, 10, 11], 2),
+            LeafTensor::new_from_const(vec![12, 3], 2),
+            LeafTensor::new_from_const(vec![5, 13], 2),
+            LeafTensor::new_from_const(vec![14, 8], 2),
+            LeafTensor::new_from_const(vec![10, 15], 2),
+            LeafTensor::new_from_const(vec![16, 9], 2),
+            LeafTensor::new_from_const(vec![11, 17], 2),
+            LeafTensor::new_from_const(vec![19, 20, 18, 12], 2),
+            LeafTensor::new_from_const(vec![18, 13, 21, 22], 2),
+            LeafTensor::new_from_const(vec![23, 24, 20, 14], 2),
+            LeafTensor::new_from_const(vec![22, 15, 25, 26], 2),
+            LeafTensor::new_from_const(vec![27, 28, 24, 16], 2),
+            LeafTensor::new_from_const(vec![26, 17, 29, 30], 2),
+            LeafTensor::new_from_const(vec![31, 19], 2),
+            LeafTensor::new_from_const(vec![21, 32], 2),
+            LeafTensor::new_from_const(vec![33, 23], 2),
+            LeafTensor::new_from_const(vec![25, 34], 2),
+            LeafTensor::new_from_const(vec![35, 27], 2),
+            LeafTensor::new_from_const(vec![29, 36], 2),
+            LeafTensor::new_from_const(vec![37, 28], 2),
+            LeafTensor::new_from_const(vec![30, 38], 2),
+            LeafTensor::new_from_const(vec![31], 2),
+            LeafTensor::new_from_const(vec![32], 2),
+            LeafTensor::new_from_const(vec![33], 2),
+            LeafTensor::new_from_const(vec![34], 2),
+            LeafTensor::new_from_const(vec![35], 2),
+            LeafTensor::new_from_const(vec![36], 2),
+            LeafTensor::new_from_const(vec![37], 2),
+            LeafTensor::new_from_const(vec![38], 2),
         ];
 
         assert_eq!(circuit.tensors().len(), 33);
         for (tensor, ref_tensor) in zip(circuit.tensors(), ref_legs) {
+            let tensor = tensor.as_leaf().unwrap();
             assert_eq!(tensor.legs(), ref_tensor.legs());
             assert_eq!(tensor.bond_dims(), ref_tensor.bond_dims());
         }

--- a/tnc/src/builders/sycamore_circuit.rs
+++ b/tnc/src/builders/sycamore_circuit.rs
@@ -84,7 +84,10 @@ mod tests {
         let circuit = sycamore_circuit(3, 3, &mut rng);
         let (tn, _) = circuit.into_amplitude_network(&"0".repeat(3));
 
-        let rank_counts = tn.tensors().iter().counts_by(|t| t.legs().len());
+        let rank_counts = tn
+            .tensors()
+            .iter()
+            .counts_by(|t| t.as_leaf().unwrap().legs().len());
         assert_eq!(rank_counts.len(), 3);
         // 3 initial state, 3 final state
         assert_eq!(rank_counts[&1], 6);

--- a/tnc/src/contractionpath/communication_schemes.rs
+++ b/tnc/src/contractionpath/communication_schemes.rs
@@ -11,7 +11,7 @@ use crate::contractionpath::paths::weighted_branchbound::WeightedBranchBound;
 use crate::contractionpath::paths::{ContractionPathResult, CostType, Pathfinder};
 use crate::contractionpath::SimplePath;
 use crate::tensornetwork::partitioning::{communication_partitioning, PartitioningStrategy};
-use crate::tensornetwork::tensor::Tensor;
+use crate::tensornetwork::tensor::{CompositeTensor, LeafTensor};
 
 /// The scheme used to find a contraction path for the final fan-in of tensors
 /// between MPI ranks.
@@ -48,7 +48,7 @@ impl fmt::Display for CommunicationScheme {
 impl CommunicationScheme {
     pub(crate) fn communication_path<R>(
         &self,
-        children_tensors: &[Tensor],
+        children_tensors: &[LeafTensor],
         latency_map: &FxHashMap<usize, f64>,
         rng: Option<&mut R>,
     ) -> SimplePath
@@ -72,21 +72,24 @@ impl CommunicationScheme {
     }
 }
 
-fn greedy(children_tensors: &[Tensor], _latency_map: &FxHashMap<usize, f64>) -> SimplePath {
-    let communication_tensors = Tensor::new_composite(children_tensors.to_vec());
+fn greedy(children_tensors: &[LeafTensor], _latency_map: &FxHashMap<usize, f64>) -> SimplePath {
+    let communication_tensors = CompositeTensor::new(children_tensors.to_vec());
     let mut opt = Cotengrust::new(OptMethod::Greedy);
     let result = opt.find_path(&communication_tensors);
     result.replace_path().into_simple()
 }
 
-fn bipartition(children_tensors: &[Tensor], _latency_map: &FxHashMap<usize, f64>) -> SimplePath {
+fn bipartition(
+    children_tensors: &[LeafTensor],
+    _latency_map: &FxHashMap<usize, f64>,
+) -> SimplePath {
     let children_tensors = children_tensors.iter().cloned().enumerate().collect_vec();
     let imbalance = 0.03;
     tensor_bipartition(&children_tensors, imbalance)
 }
 
 fn bipartition_sweep<R>(
-    children_tensors: &[Tensor],
+    children_tensors: &[LeafTensor],
     latency_map: &FxHashMap<usize, f64>,
     rng: &mut R,
 ) -> SimplePath
@@ -120,18 +123,18 @@ where
 }
 
 fn weighted_branchbound(
-    children_tensors: &[Tensor],
+    children_tensors: &[LeafTensor],
     latency_map: &FxHashMap<usize, f64>,
 ) -> SimplePath {
-    let communication_tensors = Tensor::new_composite(children_tensors.to_vec());
+    let communication_tensors = CompositeTensor::new(children_tensors.to_vec());
 
     let mut opt = WeightedBranchBound::new(Some(10), 5., latency_map.clone(), CostType::Flops);
     let result = opt.find_path(&communication_tensors);
     result.replace_path().into_simple()
 }
 
-fn branchbound(children_tensors: &[Tensor]) -> SimplePath {
-    let communication_tensors = Tensor::new_composite(children_tensors.to_vec());
+fn branchbound(children_tensors: &[LeafTensor]) -> SimplePath {
+    let communication_tensors = CompositeTensor::new(children_tensors.to_vec());
     let latency_map = (0..children_tensors.len()).map(|i| (i, 0.0)).collect();
 
     let mut opt = WeightedBranchBound::new(Some(10), 5., latency_map, CostType::Flops);
@@ -142,9 +145,9 @@ fn branchbound(children_tensors: &[Tensor]) -> SimplePath {
 /// Uses recursive bipartitioning to identify a communication scheme for final tensors
 /// Returns root id of subtree, parallel contraction cost as f64, resultant tensor and prior contraction sequence
 fn tensor_bipartition_recursive(
-    children_tensor: &[(usize, Tensor)],
+    children_tensor: &[(usize, LeafTensor)],
     imbalance: f64,
-) -> (usize, Tensor, SimplePath) {
+) -> (usize, LeafTensor, SimplePath) {
     let k = 2;
     let min = true;
 
@@ -203,13 +206,13 @@ fn tensor_bipartition_recursive(
 
 /// Repeatedly bipartitions tensor network to obtain communication scheme
 /// Assumes that all tensors contracted do so in parallel
-fn tensor_bipartition(children_tensor: &[(usize, Tensor)], imbalance: f64) -> SimplePath {
+fn tensor_bipartition(children_tensor: &[(usize, LeafTensor)], imbalance: f64) -> SimplePath {
     let (_, _, contraction_path) = tensor_bipartition_recursive(children_tensor, imbalance);
     contraction_path
 }
 
-fn random_greedy(children_tensors: &[Tensor]) -> SimplePath {
-    let communication_tensors = Tensor::new_composite(children_tensors.to_vec());
+fn random_greedy(children_tensors: &[LeafTensor]) -> SimplePath {
+    let communication_tensors = CompositeTensor::new(children_tensors.to_vec());
 
     let mut opt = Cotengrust::new(OptMethod::RandomGreedy(100));
     let result = opt.find_path(&communication_tensors);
@@ -223,9 +226,7 @@ mod tests {
     use itertools::Itertools;
     use rustc_hash::FxHashMap;
 
-    use crate::{
-        contractionpath::contraction_cost::communication_path_cost, tensornetwork::tensor::Tensor,
-    };
+    use crate::contractionpath::contraction_cost::communication_path_cost;
 
     fn setup_simple_partition_data() -> FxHashMap<usize, f64> {
         FxHashMap::from_iter([(0, 40.), (1, 30.), (2, 50.)])
@@ -234,13 +235,13 @@ mod tests {
     /// Tensor ids in contraction tree included in variable name for easy tracking
     /// This example prioritizes contracting tensor1 & tensor 2 using the greedy cost function
     /// However, the partition cost of tensor 2 is very high, which makes contracting it later more attractive by reducing wait-time
-    fn setup_simple() -> Vec<Tensor> {
+    fn setup_simple() -> Vec<LeafTensor> {
         let bond_dims =
             FxHashMap::from_iter([(0, 2), (1, 2), (2, 2), (3, 2), (4, 2), (5, 2), (6, 2)]);
 
-        let tensor0 = Tensor::new_from_map(vec![3, 4, 5], &bond_dims);
-        let tensor1 = Tensor::new_from_map(vec![0, 1, 3, 4], &bond_dims);
-        let tensor2 = Tensor::new_from_map(vec![0, 1, 2, 5, 6], &bond_dims);
+        let tensor0 = LeafTensor::new_from_map(vec![3, 4, 5], &bond_dims);
+        let tensor1 = LeafTensor::new_from_map(vec![0, 1, 3, 4], &bond_dims);
+        let tensor2 = LeafTensor::new_from_map(vec![0, 1, 2, 5, 6], &bond_dims);
         vec![tensor0, tensor1, tensor2]
     }
 

--- a/tnc/src/contractionpath/contraction_cost.rs
+++ b/tnc/src/contractionpath/contraction_cost.rs
@@ -5,25 +5,25 @@ use num_complex::Complex64;
 
 use crate::{
     contractionpath::{ContractionPath, SimplePathRef},
+    tensornetwork::tensor::LeafTensor,
     tensornetwork::tensor::Tensor,
 };
 
-/// Returns Schroedinger contraction time complexity of contracting two [`Tensor`]
-/// objects. Considers cost of complex operations.
+/// Returns Schroedinger contraction time complexity of contracting two
+/// [`LeafTensor`] objects. Considers cost of complex operations.
 ///
 /// # Examples
 /// ```
-/// # use tnc::tensornetwork::tensor::Tensor;
+/// # use tnc::tensornetwork::tensor::LeafTensor;
 /// # use tnc::contractionpath::contraction_cost::contract_cost_tensors;
 /// # use rustc_hash::FxHashMap;
 /// let bond_dims = FxHashMap::from_iter([(0, 5),(1, 7), (2, 9), (3, 11), (4, 13)]);
-/// let tensor1 = Tensor::new_from_map(vec![0, 1, 2], &bond_dims);
-/// let tensor2 = Tensor::new_from_map(vec![2, 3, 4], &bond_dims);
+/// let tensor1 = LeafTensor::new_from_map(vec![0, 1, 2], &bond_dims);
+/// let tensor2 = LeafTensor::new_from_map(vec![2, 3, 4], &bond_dims);
 /// // result = [0, 1, 2, 3, 4] // cost of (9-1)*54*5005 = 350350;
-/// let tn = Tensor::new_composite(vec![tensor1, tensor2]);
-/// assert_eq!(contract_cost_tensors(&tn.tensor(0), &tn.tensor(1)), 350350.);
+/// assert_eq!(contract_cost_tensors(&tensor1, &tensor2), 350350.);
 /// ```
-pub fn contract_cost_tensors(t_1: &Tensor, t_2: &Tensor) -> f64 {
+pub fn contract_cost_tensors(t_1: &LeafTensor, t_2: &LeafTensor) -> f64 {
     let final_dims = t_1 ^ t_2;
     let shared_dims = t_1 & t_2;
 
@@ -31,44 +31,42 @@ pub fn contract_cost_tensors(t_1: &Tensor, t_2: &Tensor) -> f64 {
     (single_loop_cost - 1f64).mul_add(2f64, single_loop_cost * 6f64) * final_dims.size()
 }
 
-/// Returns Schroedinger contraction time complexity of contracting two [`Tensor`]
-/// objects. Naive op cost, does not consider costs of multiplication.
+/// Returns Schroedinger contraction time complexity of contracting two
+/// [`LeafTensor`] objects. Naive op cost, does not consider costs of multiplication.
 ///
 /// # Examples
 /// ```
-/// # use tnc::tensornetwork::tensor::Tensor;
+/// # use tnc::tensornetwork::tensor::LeafTensor;
 /// # use tnc::contractionpath::contraction_cost::contract_op_cost_tensors;
 /// # use rustc_hash::FxHashMap;
 /// let bond_dims = FxHashMap::from_iter([(0, 5),(1, 7), (2, 9), (3, 11), (4, 13)]);
-/// let tensor1 = Tensor::new_from_map(vec![0, 1, 2], &bond_dims);
-/// let tensor2 = Tensor::new_from_map(vec![2, 3, 4], &bond_dims);
+/// let tensor1 = LeafTensor::new_from_map(vec![0, 1, 2], &bond_dims);
+/// let tensor2 = LeafTensor::new_from_map(vec![2, 3, 4], &bond_dims);
 /// // result = [0, 1, 2, 3, 4] // cost of 5*7*9*11*13 = 45045;
-/// let tn = Tensor::new_composite(vec![tensor1, tensor2]);
-/// assert_eq!(contract_op_cost_tensors(&tn.tensor(0), &tn.tensor(1)), 45045.);
+/// assert_eq!(contract_op_cost_tensors(&tensor1, &tensor2), 45045.);
 /// ```
 #[inline]
-pub fn contract_op_cost_tensors(t_1: &Tensor, t_2: &Tensor) -> f64 {
+pub fn contract_op_cost_tensors(t_1: &LeafTensor, t_2: &LeafTensor) -> f64 {
     let all_dims = t_1 | t_2;
     all_dims.size()
 }
 
-/// Returns Schroedinger contraction space complexity of contracting two [`Tensor`]
-/// objects.
+/// Returns Schroedinger contraction space complexity of contracting two
+/// [`LeafTensor`] objects.
 ///
 /// # Examples
 /// ```
-/// # use tnc::tensornetwork::tensor::Tensor;
+/// # use tnc::tensornetwork::tensor::LeafTensor;
 /// # use tnc::contractionpath::contraction_cost::contract_size_tensors;
 /// # use rustc_hash::FxHashMap;
 /// let bond_dims = FxHashMap::from_iter([(0, 5),(1, 7), (2, 9), (3, 11), (4, 13)]);
-/// let tensor1 = Tensor::new_from_map(vec![0, 1, 2], &bond_dims); // 315 entries
-/// let tensor2 = Tensor::new_from_map(vec![2, 3, 4], &bond_dims); // 1287 entries
+/// let tensor1 = LeafTensor::new_from_map(vec![0, 1, 2], &bond_dims); // 315 entries
+/// let tensor2 = LeafTensor::new_from_map(vec![2, 3, 4], &bond_dims); // 1287 entries
 /// // result = [0, 1, 3, 4] //  5005 entries -> total 6607 entries
-/// let tn = Tensor::new_composite(vec![tensor1, tensor2]);
-/// assert_eq!(contract_size_tensors(&tn.tensor(0), &tn.tensor(1)), 6607.);
+/// assert_eq!(contract_size_tensors(&tensor1, &tensor2), 6607.);
 /// ```
 #[inline]
-pub fn contract_size_tensors(t_1: &Tensor, t_2: &Tensor) -> f64 {
+pub fn contract_size_tensors(t_1: &LeafTensor, t_2: &LeafTensor) -> f64 {
     let diff = t_1 ^ t_2;
     diff.size() + t_1.size() + t_2.size()
 }
@@ -78,18 +76,17 @@ pub fn contract_size_tensors(t_1: &Tensor, t_2: &Tensor) -> f64 {
 ///
 /// # Examples
 /// ```
-/// # use tnc::tensornetwork::tensor::Tensor;
+/// # use tnc::tensornetwork::tensor::LeafTensor;
 /// # use tnc::contractionpath::contraction_cost::contract_size_tensors_bytes;
 /// # use rustc_hash::FxHashMap;
 /// let bond_dims = FxHashMap::from_iter([(0, 5),(1, 7), (2, 9), (3, 11), (4, 13)]);
-/// let tensor1 = Tensor::new_from_map(vec![0, 1, 2], &bond_dims); // 315 entries
-/// let tensor2 = Tensor::new_from_map(vec![2, 3, 4], &bond_dims); // 1287 entries
+/// let tensor1 = LeafTensor::new_from_map(vec![0, 1, 2], &bond_dims); // 315 entries
+/// let tensor2 = LeafTensor::new_from_map(vec![2, 3, 4], &bond_dims); // 1287 entries
 /// // result = [0, 1, 3, 4] //  5005 entries -> total 6607 entries
-/// let tn = Tensor::new_composite(vec![tensor1, tensor2]);
-/// assert_eq!(contract_size_tensors_bytes(&tn.tensor(0), &tn.tensor(1)), 6607. * 16.);
+/// assert_eq!(contract_size_tensors_bytes(&tensor1, &tensor2), 6607. * 16.);
 /// ```
 #[inline]
-pub fn contract_size_tensors_bytes(i: &Tensor, j: &Tensor) -> f64 {
+pub fn contract_size_tensors_bytes(i: &LeafTensor, j: &LeafTensor) -> f64 {
     contract_size_tensors(i, j) * std::mem::size_of::<Complex64>() as f64
 }
 
@@ -124,27 +121,30 @@ pub fn contract_path_cost(
 fn contract_path_custom_cost(
     inputs: &[Tensor],
     contract_path: &ContractionPath,
-    cost_function: fn(&Tensor, &Tensor) -> f64,
-    size_function: fn(&Tensor, &Tensor) -> f64,
+    cost_function: fn(&LeafTensor, &LeafTensor) -> f64,
+    size_function: fn(&LeafTensor, &LeafTensor) -> f64,
 ) -> (f64, f64) {
     let mut op_cost = 0f64;
     let mut mem_cost = 0f64;
     let mut inputs = inputs.to_vec();
 
     for (i, path) in &contract_path.nested {
+        let composite = inputs[*i].as_composite().unwrap();
         let costs =
-            contract_path_custom_cost(inputs[*i].tensors(), path, cost_function, size_function);
+            contract_path_custom_cost(composite.tensors(), path, cost_function, size_function);
         op_cost += costs.0;
         mem_cost = mem_cost.max(costs.1);
-        inputs[*i] = inputs[*i].external_tensor();
+        inputs[*i] = composite.external_tensor().into();
     }
 
-    for &(i, j) in &contract_path.toplevel {
-        op_cost += cost_function(&inputs[i], &inputs[j]);
-        let ij = &inputs[i] ^ &inputs[j];
-        let new_mem_cost = size_function(&inputs[i], &inputs[j]);
+    for (i, j) in &contract_path.toplevel {
+        let ti = inputs[*i].as_leaf().unwrap();
+        let tj = inputs[*j].as_leaf().unwrap();
+        op_cost += cost_function(ti, tj);
+        let tij = ti ^ tj;
+        let new_mem_cost = size_function(ti, tj);
         mem_cost = mem_cost.max(new_mem_cost);
-        inputs[i] = ij;
+        inputs[*i] = tij.into();
     }
 
     (op_cost, mem_cost)
@@ -154,7 +154,7 @@ fn contract_path_custom_cost(
 /// and using the sum metric. Additionally returns the space complexity.
 #[inline]
 pub fn communication_path_op_costs(
-    inputs: &[Tensor],
+    inputs: &[LeafTensor],
     contract_path: SimplePathRef,
     only_count_ops: bool,
     tensor_cost: Option<&[f64]>,
@@ -176,7 +176,7 @@ pub fn communication_path_op_costs(
 /// * `only_circital_path` - If `true`, only counts the cost along the critical path, otherwise the sum of all costs
 /// * `tensor_costs` - Initial cost for each tensor
 pub fn communication_path_cost(
-    inputs: &[Tensor],
+    inputs: &[LeafTensor],
     contract_path: SimplePathRef,
     only_count_ops: bool,
     only_critical_path: bool,
@@ -215,9 +215,9 @@ pub fn communication_path_cost(
 /// * `cost_function` - Function to calculate cost of contracting two tensors
 /// * `tensor_costs` - Initial cost for each tensor
 fn communication_path_custom_cost(
-    inputs: &[Tensor],
+    inputs: &[LeafTensor],
     contract_path: SimplePathRef,
-    cost_function: fn(&Tensor, &Tensor) -> f64,
+    cost_function: fn(&LeafTensor, &LeafTensor) -> f64,
     only_critical_path: bool,
     tensor_cost: &[f64],
 ) -> (f64, f64) {
@@ -254,9 +254,9 @@ fn communication_path_custom_cost(
 pub fn compute_memory_requirements(
     inputs: &[Tensor],
     contract_path: &ContractionPath,
-    memory_estimator: fn(&Tensor, &Tensor) -> f64,
+    memory_estimator: fn(&LeafTensor, &LeafTensor) -> f64,
 ) -> f64 {
-    fn id(_: &Tensor, _: &Tensor) -> f64 {
+    fn id(_: &LeafTensor, _: &LeafTensor) -> f64 {
         0.0
     }
     let (_, mem) = contract_path_custom_cost(inputs, contract_path, id, memory_estimator);
@@ -270,19 +270,19 @@ mod tests {
     use rustc_hash::FxHashMap;
 
     use crate::path;
-    use crate::tensornetwork::tensor::Tensor;
+    use crate::tensornetwork::tensor::CompositeTensor;
 
-    fn setup_simple() -> Tensor {
+    fn setup_simple() -> CompositeTensor {
         let bond_dims =
             FxHashMap::from_iter([(0, 5), (1, 2), (2, 6), (3, 8), (4, 1), (5, 3), (6, 4)]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
         ])
     }
 
-    fn setup_complex() -> Tensor {
+    fn setup_complex() -> CompositeTensor {
         let bond_dims = FxHashMap::from_iter([
             (0, 5),
             (1, 2),
@@ -296,29 +296,29 @@ mod tests {
             (9, 2),
         ]);
         let t1_tensors = vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
         ];
-        let t1 = Tensor::new_composite(t1_tensors);
+        let t1 = CompositeTensor::new(t1_tensors);
 
         let t2_tensors = vec![
-            Tensor::new_from_map(vec![5, 6, 8], &bond_dims),
-            Tensor::new_from_map(vec![7, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 6, 8], &bond_dims),
+            LeafTensor::new_from_map(vec![7, 8, 9], &bond_dims),
         ];
-        let t2 = Tensor::new_composite(t2_tensors);
-        Tensor::new_composite(vec![t1, t2])
+        let t2 = CompositeTensor::new(t2_tensors);
+        CompositeTensor::new(vec![t1, t2])
     }
 
-    fn setup_parallel() -> Tensor {
+    fn setup_parallel() -> Vec<LeafTensor> {
         let bond_dims =
             FxHashMap::from_iter([(0, 5), (1, 2), (2, 6), (3, 8), (4, 1), (5, 3), (6, 4)]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-            Tensor::new_from_map(vec![5, 6], &bond_dims),
-        ])
+        vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 6], &bond_dims),
+        ]
     }
 
     #[test]
@@ -369,28 +369,28 @@ mod tests {
 
     #[test]
     fn test_communication_path_cost_only_ops() {
-        let tn = setup_parallel();
+        let tensors = setup_parallel();
         let (op_cost, mem_cost) =
-            communication_path_cost(tn.tensors(), &[(0, 1), (2, 3), (0, 2)], true, true, None);
+            communication_path_cost(&tensors, &[(0, 1), (2, 3), (0, 2)], true, true, None);
         assert_eq!(op_cost, 490.);
         assert_eq!(mem_cost, 538.);
     }
 
     #[test]
     fn test_communication_path_cost() {
-        let tn = setup_parallel();
+        let tensors = setup_parallel();
         let (op_cost, mem_cost) =
-            communication_path_cost(tn.tensors(), &[(0, 1), (2, 3), (0, 1)], false, true, None);
+            communication_path_cost(&tensors, &[(0, 1), (2, 3), (0, 1)], false, true, None);
         assert_eq!(op_cost, 7564.);
         assert_eq!(mem_cost, 538.);
     }
 
     #[test]
     fn test_communication_path_cost_only_ops_with_partition_cost() {
-        let tn = setup_parallel();
+        let tensors = setup_parallel();
         let tensor_cost = vec![20., 30., 80., 10.];
         let (op_cost, mem_cost) = communication_path_cost(
-            tn.tensors(),
+            &tensors,
             &[(0, 1), (2, 3), (0, 2)],
             true,
             true,
@@ -402,10 +402,10 @@ mod tests {
 
     #[test]
     fn test_communication_path_cost_with_partition_cost() {
-        let tn = setup_parallel();
+        let tensors = setup_parallel();
         let tensor_cost = vec![20., 30., 80., 10.];
         let (op_cost, mem_cost) = communication_path_cost(
-            tn.tensors(),
+            &tensors,
             &[(0, 1), (2, 3), (0, 1)],
             false,
             true,

--- a/tnc/src/contractionpath/contraction_tree.rs
+++ b/tnc/src/contractionpath/contraction_tree.rs
@@ -9,7 +9,7 @@ use crate::contractionpath::contraction_tree::node::{
 };
 use crate::contractionpath::paths::validate_path;
 use crate::contractionpath::{ContractionPath, SimplePath, SimplePathRef};
-use crate::tensornetwork::tensor::Tensor;
+use crate::tensornetwork::tensor::{CompositeTensor, LeafTensor};
 
 pub mod balancing;
 mod node;
@@ -18,8 +18,11 @@ mod utils;
 /// Struct representing the full contraction path of a given [`Tensor`] object.
 #[derive(Default, Debug, Clone)]
 pub struct ContractionTree {
+    /// Map of node ids to the actual nodes.
     nodes: FxHashMap<usize, NodeRef>,
+    /// Map of tree level to the node ids on this level.
     partitions: FxHashMap<usize, Vec<usize>>,
+    /// Reference to the root node.
     root: WeakNodeRef,
 }
 
@@ -42,7 +45,7 @@ impl ContractionTree {
     /// Populates `nodes` and `partitions` with the tree structure of the contraction
     /// `path`.
     fn from_contraction_path_recurse(
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         path: &ContractionPath,
         nodes: &mut FxHashMap<usize, NodeRef>,
         partitions: &mut FxHashMap<usize, Vec<usize>>,
@@ -52,7 +55,7 @@ impl ContractionTree {
 
         // Obtain tree structure from composite tensors
         for (path_id, path) in path.nested.iter().sorted_by_key(|&(path_id, _)| *path_id) {
-            let composite_tensor = tensor.tensor(*path_id);
+            let composite_tensor = tensor.tensor(*path_id).as_composite().unwrap();
             let mut new_prefix = prefix.to_owned();
             new_prefix.push(*path_id);
             Self::from_contraction_path_recurse(
@@ -96,7 +99,7 @@ impl ContractionTree {
     /// represents all intermediate tensors and costs of given contraction path and
     /// tensor network.
     #[must_use]
-    pub fn from_contraction_path(tensor: &Tensor, path: &ContractionPath) -> Self {
+    pub fn from_contraction_path(tensor: &CompositeTensor, path: &ContractionPath) -> Self {
         validate_path(path);
         let mut nodes = FxHashMap::default();
         let mut partitions = FxHashMap::default();
@@ -256,17 +259,20 @@ impl ContractionTree {
 
     fn tree_weights_recurse(
         node: &Node,
-        tn: &Tensor,
+        tn: &CompositeTensor,
         weights: &mut FxHashMap<usize, f64>,
-        scratch: &mut FxHashMap<usize, Tensor>,
-        cost_function: fn(&Tensor, &Tensor) -> f64,
+        scratch: &mut FxHashMap<usize, LeafTensor>,
+        cost_function: fn(&LeafTensor, &LeafTensor) -> f64,
     ) {
         if node.is_leaf() {
             let Some(tensor_index) = &node.tensor_index() else {
                 panic!("All leaf nodes should have a tensor index")
             };
             weights.insert(node.id(), 0f64);
-            scratch.insert(node.id(), tn.nested_tensor(tensor_index).clone());
+            scratch.insert(
+                node.id(),
+                tn.nested_tensor(tensor_index).as_leaf().unwrap().clone(),
+            );
             return;
         }
 
@@ -297,8 +303,8 @@ impl ContractionTree {
     pub fn tree_weights(
         &self,
         node_id: usize,
-        tn: &Tensor,
-        cost_function: fn(&Tensor, &Tensor) -> f64,
+        tn: &CompositeTensor,
+        cost_function: fn(&LeafTensor, &LeafTensor) -> f64,
     ) -> FxHashMap<usize, f64> {
         let mut weights = FxHashMap::default();
         let mut scratch = FxHashMap::default();
@@ -369,13 +375,16 @@ impl ContractionTree {
     ///
     /// # Returns
     /// Empty tensor with legs (dimensions) of data after fully contracted.
-    pub fn tensor(&self, node_id: usize, tensor: &Tensor) -> Tensor {
+    pub fn tensor(&self, node_id: usize, tensor: &CompositeTensor) -> LeafTensor {
         let leaf_nodes = self.leaf_ids(node_id);
-        let mut new_tensor = Tensor::default();
+        let mut new_tensor = LeafTensor::default();
 
         for leaf_id in leaf_nodes {
             new_tensor = &new_tensor
-                ^ tensor.nested_tensor(self.node(leaf_id).tensor_index().as_ref().unwrap());
+                ^ tensor
+                    .nested_tensor(self.node(leaf_id).tensor_index().as_ref().unwrap())
+                    .as_leaf()
+                    .unwrap();
         }
         new_tensor
     }
@@ -384,15 +393,18 @@ impl ContractionTree {
 fn populate_subtree_tensor_map_recursive(
     contraction_tree: &ContractionTree,
     node_id: usize,
-    node_tensor_map: &mut FxHashMap<usize, Tensor>,
-    tensor_network: &Tensor,
+    node_tensor_map: &mut FxHashMap<usize, LeafTensor>,
+    tensor_network: &CompositeTensor,
     height_limit: Option<usize>,
-) -> (Tensor, usize) {
+) -> (LeafTensor, usize) {
     let node = contraction_tree.node(node_id);
 
     if node.is_leaf() {
         let tensor_index = node.tensor_index().unwrap();
-        let t = tensor_network.nested_tensor(tensor_index);
+        let t = tensor_network
+            .nested_tensor(tensor_index)
+            .as_leaf()
+            .unwrap();
         node_tensor_map.insert(node.id(), t.clone());
         (t.clone(), 0)
     } else {
@@ -438,9 +450,9 @@ fn populate_subtree_tensor_map_recursive(
 fn populate_subtree_tensor_map(
     contraction_tree: &ContractionTree,
     node_id: usize,
-    tensor_network: &Tensor,
+    tensor_network: &CompositeTensor,
     height_limit: Option<usize>,
-) -> FxHashMap<usize, Tensor> {
+) -> FxHashMap<usize, LeafTensor> {
     let mut node_tensor_map = FxHashMap::default();
     let _ = populate_subtree_tensor_map_recursive(
         contraction_tree,
@@ -464,8 +476,8 @@ fn populate_subtree_tensor_map(
 fn populate_leaf_node_tensor_map(
     contraction_tree: &ContractionTree,
     node_id: usize,
-    tensor_network: &Tensor,
-) -> FxHashMap<usize, Tensor> {
+    tensor_network: &CompositeTensor,
+) -> FxHashMap<usize, LeafTensor> {
     let mut node_tensor_map = FxHashMap::default();
     for leaf_node_id in contraction_tree.leaf_ids(node_id) {
         node_tensor_map.insert(
@@ -493,21 +505,21 @@ mod tests {
     use crate::path;
     use crate::tensornetwork::tensor::{EdgeIndex, Tensor};
 
-    fn setup_simple() -> (Tensor, ContractionPath, FxHashMap<EdgeIndex, u64>) {
+    fn setup_simple() -> (CompositeTensor, ContractionPath, FxHashMap<EdgeIndex, u64>) {
         let bond_dims =
             FxHashMap::from_iter([(0, 5), (1, 2), (2, 6), (3, 8), (4, 1), (5, 3), (6, 4)]);
         (
-            Tensor::new_composite(vec![
-                Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
+            CompositeTensor::new(vec![
+                LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
             ]),
             path![(0, 1), (2, 0)],
             bond_dims,
         )
     }
 
-    fn setup_complex() -> (Tensor, ContractionPath, FxHashMap<EdgeIndex, u64>) {
+    fn setup_complex() -> (CompositeTensor, ContractionPath, FxHashMap<EdgeIndex, u64>) {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -522,20 +534,20 @@ mod tests {
             (10, 5),
         ]);
         (
-            Tensor::new_composite(vec![
-                Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-                Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-                Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
-                Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+            CompositeTensor::new(vec![
+                LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+                LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+                LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
+                LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
             ]),
             path![(1, 5), (0, 1), (3, 4), (2, 3), (0, 2)],
             bond_dims,
         )
     }
 
-    fn setup_unbalanced() -> (Tensor, ContractionPath) {
+    fn setup_unbalanced() -> (CompositeTensor, ContractionPath) {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -551,19 +563,19 @@ mod tests {
             (11, 17),
         ]);
         (
-            Tensor::new_composite(vec![
-                Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-                Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-                Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
-                Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+            CompositeTensor::new(vec![
+                LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+                LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+                LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
+                LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
             ]),
             path![(0, 1), (2, 0), (3, 2), (4, 3), (5, 4)],
         )
     }
 
-    fn setup_nested() -> (Tensor, ContractionPath) {
+    fn setup_nested() -> (CompositeTensor, ContractionPath) {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -579,24 +591,24 @@ mod tests {
             (11, 17),
         ]);
 
-        let t0 = Tensor::new_from_map(vec![4, 3, 2], &bond_dims);
-        let t1 = Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims);
-        let t2 = Tensor::new_from_map(vec![4, 5, 6], &bond_dims);
-        let t3 = Tensor::new_from_map(vec![6, 8, 9], &bond_dims);
-        let t4 = Tensor::new_from_map(vec![5, 1, 0], &bond_dims);
-        let t5 = Tensor::new_from_map(vec![10, 8, 9], &bond_dims);
+        let t0 = LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims);
+        let t1 = LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims);
+        let t2 = LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims);
+        let t3 = LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims);
+        let t4 = LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims);
+        let t5 = LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims);
 
-        let t01 = Tensor::new_composite(vec![t0, t1]);
-        let t23 = Tensor::new_composite(vec![t2, t3]);
-        let t45 = Tensor::new_composite(vec![t4, t5]);
-        let tensor_network = Tensor::new_composite(vec![t01, t23, t45]);
+        let t01 = CompositeTensor::new(vec![t0, t1]);
+        let t23 = CompositeTensor::new(vec![t2, t3]);
+        let t45 = CompositeTensor::new(vec![t4, t5]);
+        let tensor_network = CompositeTensor::new(vec![t01, t23, t45]);
         (
             tensor_network,
             path![{(0, [(0, 1)]), (1, [(0, 1)]), (2, [(0, 1)])}, (0, 1), (0, 2)],
         )
     }
 
-    fn setup_double_nested() -> (Tensor, ContractionPath) {
+    fn setup_double_nested() -> (CompositeTensor, ContractionPath) {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -612,18 +624,20 @@ mod tests {
             (11, 17),
         ]);
 
-        let t0 = Tensor::new_from_map(vec![4, 3, 2], &bond_dims);
-        let t1 = Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims);
-        let t2 = Tensor::new_from_map(vec![4, 5, 6], &bond_dims);
-        let t3 = Tensor::new_from_map(vec![6, 8, 9], &bond_dims);
-        let t4 = Tensor::new_from_map(vec![5, 1, 0], &bond_dims);
-        let t5 = Tensor::new_from_map(vec![10, 8, 9], &bond_dims);
+        let t0 = LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims);
+        let t1 = LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims);
+        let t2 = LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims);
+        let t3 = LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims);
+        let t4 = LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims);
+        let t5 = LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims);
 
-        let t01 = Tensor::new_composite(vec![t0, t1]);
-        let t012 = Tensor::new_composite(vec![t01, t2]);
-        let t34 = Tensor::new_composite(vec![t3, t4]);
-        let t345 = Tensor::new_composite(vec![t34, t5]);
-        let tensor_network = Tensor::new_composite(vec![t012, t345]);
+        let t01 = CompositeTensor::new(vec![t0, t1]);
+        let t01: Tensor = t01.into();
+        let t012 = CompositeTensor::new(vec![t01, t2.into()]);
+        let t34 = CompositeTensor::new(vec![t3, t4]);
+        let t34: Tensor = t34.into();
+        let t345 = CompositeTensor::new(vec![t34, t5.into()]);
+        let tensor_network = CompositeTensor::new(vec![t012, t345]);
         (
             tensor_network,
             path![
@@ -963,11 +977,11 @@ mod tests {
         populate_subtree_tensor_map_recursive(&tree, 4, &mut node_tensor_map, &tensor, None);
 
         let ref_node_tensor_map = FxHashMap::from_iter([
-            (0, Tensor::new_from_map(vec![4, 3, 2], &bond_dims)),
-            (1, Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims)),
-            (2, Tensor::new_from_map(vec![4, 5, 6], &bond_dims)),
-            (3, Tensor::new_from_map(vec![4, 0, 1], &bond_dims)),
-            (4, Tensor::new_from_map(vec![5, 6, 0, 1], &bond_dims)),
+            (0, LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims)),
+            (1, LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims)),
+            (2, LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims)),
+            (3, LeafTensor::new_from_map(vec![4, 0, 1], &bond_dims)),
+            (4, LeafTensor::new_from_map(vec![5, 6, 0, 1], &bond_dims)),
         ]);
 
         for (key, value) in ref_node_tensor_map {
@@ -983,17 +997,17 @@ mod tests {
         populate_subtree_tensor_map_recursive(&tree, 10, &mut node_tensor_map, &tensor, None);
 
         let ref_node_tensor_map = FxHashMap::from_iter([
-            (0, Tensor::new_from_map(vec![4, 3, 2], &bond_dims)),
-            (1, Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims)),
-            (2, Tensor::new_from_map(vec![4, 5, 6], &bond_dims)),
-            (3, Tensor::new_from_map(vec![6, 8, 9], &bond_dims)),
-            (4, Tensor::new_from_map(vec![10, 8, 9], &bond_dims)),
-            (5, Tensor::new_from_map(vec![5, 1, 0], &bond_dims)),
-            (6, Tensor::new_from_map(vec![3, 2, 5], &bond_dims)),
-            (7, Tensor::new_from_map(vec![4, 5], &bond_dims)),
-            (8, Tensor::new_from_map(vec![6, 10], &bond_dims)),
-            (9, Tensor::new_from_map(vec![4, 5, 10], &bond_dims)),
-            (10, Tensor::new_from_map(vec![10], &bond_dims)),
+            (0, LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims)),
+            (1, LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims)),
+            (2, LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims)),
+            (3, LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims)),
+            (4, LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims)),
+            (5, LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims)),
+            (6, LeafTensor::new_from_map(vec![3, 2, 5], &bond_dims)),
+            (7, LeafTensor::new_from_map(vec![4, 5], &bond_dims)),
+            (8, LeafTensor::new_from_map(vec![6, 10], &bond_dims)),
+            (9, LeafTensor::new_from_map(vec![4, 5, 10], &bond_dims)),
+            (10, LeafTensor::new_from_map(vec![10], &bond_dims)),
         ]);
 
         for (key, value) in ref_node_tensor_map {
@@ -1008,14 +1022,14 @@ mod tests {
         let node_tensor_map = populate_subtree_tensor_map(&tree, 10, &tensor, Some(1));
 
         let ref_node_tensor_map = FxHashMap::from_iter([
-            (0, Tensor::new_from_map(vec![4, 3, 2], &bond_dims)),
-            (1, Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims)),
-            (2, Tensor::new_from_map(vec![4, 5, 6], &bond_dims)),
-            (3, Tensor::new_from_map(vec![6, 8, 9], &bond_dims)),
-            (4, Tensor::new_from_map(vec![10, 8, 9], &bond_dims)),
-            (5, Tensor::new_from_map(vec![5, 1, 0], &bond_dims)),
-            (6, Tensor::new_from_map(vec![3, 2, 5], &bond_dims)),
-            (8, Tensor::new_from_map(vec![6, 10], &bond_dims)),
+            (0, LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims)),
+            (1, LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims)),
+            (2, LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims)),
+            (3, LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims)),
+            (4, LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims)),
+            (5, LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims)),
+            (6, LeafTensor::new_from_map(vec![3, 2, 5], &bond_dims)),
+            (8, LeafTensor::new_from_map(vec![6, 10], &bond_dims)),
         ]);
 
         for (key, value) in ref_node_tensor_map {
@@ -1031,9 +1045,9 @@ mod tests {
         let node_tensor_map = populate_leaf_node_tensor_map(&tree, 4, &tensor);
 
         let ref_node_tensor_map = FxHashMap::from_iter([
-            (0, Tensor::new_from_map(vec![4, 3, 2], &bond_dims)),
-            (1, Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims)),
-            (2, Tensor::new_from_map(vec![4, 5, 6], &bond_dims)),
+            (0, LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims)),
+            (1, LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims)),
+            (2, LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims)),
         ]);
 
         for (key, value) in ref_node_tensor_map {
@@ -1048,11 +1062,11 @@ mod tests {
         let node_tensor_map = populate_subtree_tensor_map(&tree, 10, &tensor, None);
 
         let ref_node_tensor_map = FxHashMap::from_iter([
-            (0, Tensor::new_from_map(vec![4, 3, 2], &bond_dims)),
-            (1, Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims)),
-            (2, Tensor::new_from_map(vec![4, 5, 6], &bond_dims)),
-            (3, Tensor::new_from_map(vec![6, 8, 9], &bond_dims)),
-            (4, Tensor::new_from_map(vec![10, 8, 9], &bond_dims)),
+            (0, LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims)),
+            (1, LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims)),
+            (2, LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims)),
+            (3, LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims)),
+            (4, LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims)),
         ]);
 
         for (key, value) in ref_node_tensor_map {

--- a/tnc/src/contractionpath/contraction_tree/balancing.rs
+++ b/tnc/src/contractionpath/contraction_tree/balancing.rs
@@ -17,7 +17,7 @@ use crate::contractionpath::contraction_tree::{
 };
 use crate::contractionpath::paths::validate_path;
 use crate::contractionpath::{ContractionPath, SimplePath};
-use crate::tensornetwork::tensor::{Tensor, TensorIndex};
+use crate::tensornetwork::tensor::{CompositeTensor, LeafTensor, TensorIndex, TensorType};
 
 mod balancing_schemes;
 
@@ -33,7 +33,7 @@ where
     random_balance: Option<(usize, R)>,
     rebalance_depth: usize,
     iterations: usize,
-    objective_function: fn(&Tensor, &Tensor) -> f64,
+    objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
     communication_scheme: CommunicationScheme,
     balancing_scheme: BalancingScheme,
     memory_limit: Option<f64>,
@@ -43,7 +43,7 @@ impl BalanceSettings<StdRng> {
     pub fn new(
         rebalance_depth: usize,
         iterations: usize,
-        objective_function: fn(&Tensor, &Tensor) -> f64,
+        objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
         communication_scheme: CommunicationScheme,
         balancing_scheme: BalancingScheme,
         memory_limit: Option<f64>,
@@ -68,7 +68,7 @@ where
         random_balance: Option<(usize, R)>,
         rebalance_depth: usize,
         iterations: usize,
-        objective_function: fn(&Tensor, &Tensor) -> f64,
+        objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
         communication_scheme: CommunicationScheme,
         balancing_scheme: BalancingScheme,
         memory_limit: Option<f64>,
@@ -91,16 +91,16 @@ pub(crate) struct PartitionData {
     pub flop_cost: f64,
     pub mem_cost: f64,
     pub contraction: SimplePath,
-    pub local_tensor: Tensor,
+    pub local_tensor: LeafTensor,
 }
 
 /// Balances a partitioned tensor network to greedily optimize for a given objective.
 pub fn balance_partitions_iter<R>(
-    tensor_network: &Tensor,
+    tensor_network: &CompositeTensor,
     path: &ContractionPath,
     mut balance_settings: BalanceSettings<R>,
     rng: &mut R,
-) -> (usize, Tensor, ContractionPath, Vec<(f64, f64)>)
+) -> (usize, CompositeTensor, ContractionPath, Vec<(f64, f64)>)
 where
     R: Rng,
 {
@@ -212,7 +212,7 @@ where
 fn communicate_partitions<R>(
     partition_data: &[PartitionData],
     contraction_tree: &mut ContractionTree,
-    tensor_network: &Tensor,
+    tensor_network: &CompositeTensor,
     balance_settings: &BalanceSettings<R>,
     rng: Option<&mut R>,
 ) -> SimplePath
@@ -223,7 +223,10 @@ where
     let children_tensors = tensor_network
         .tensors()
         .iter()
-        .map(Tensor::external_tensor)
+        .map(|t| match t.kind() {
+            TensorType::Composite => t.as_composite().unwrap().external_tensor(),
+            TensorType::Leaf => t.as_leaf().unwrap().clone(),
+        })
         .collect_vec();
     let latency_map = partition_data
         .iter()
@@ -246,10 +249,10 @@ where
 fn balance_partitions<R>(
     partition_data: &mut [PartitionData],
     contraction_tree: &mut ContractionTree,
-    tensor_network: &Tensor,
+    tensor_network: &CompositeTensor,
     balance_settings: &mut BalanceSettings<R>,
     iteration: usize,
-) -> (FxHashMap<TensorIndex, ContractionPath>, Tensor)
+) -> (FxHashMap<TensorIndex, ContractionPath>, CompositeTensor)
 where
     R: Rng,
 {
@@ -443,7 +446,6 @@ where
                 },
             )| {
                 rebalanced_paths.insert(i, ContractionPath::simple(subtree_contraction.clone()));
-                let mut child_tensor = Tensor::default();
                 let leaf_ids = contraction_tree.leaf_ids(*id);
                 let leaf_tensors = leaf_ids
                     .iter()
@@ -456,7 +458,7 @@ where
                         tensor_network.nested_tensor(&nested_indices).clone()
                     })
                     .collect_vec();
-                child_tensor.push_tensors(leaf_tensors);
+                let child_tensor = CompositeTensor::new(leaf_tensors);
                 (child_tensor, *id)
             },
         )
@@ -466,8 +468,7 @@ where
         .partitions
         .insert(*rebalance_depth, partition_ids);
 
-    let mut updated_tn = Tensor::default();
-    updated_tn.push_tensors(partition_tensors);
+    let updated_tn = CompositeTensor::new(partition_tensors);
     (rebalanced_paths, updated_tn)
 }
 
@@ -480,9 +481,9 @@ where
 /// * `objective_function` - Cost function that takes in two tensors and returns an f64 cost.
 fn find_rebalance_node<R>(
     random_balance: &mut Option<(usize, R)>,
-    larger_subtree_nodes: &FxHashMap<usize, Tensor>,
-    smaller_subtree_nodes: &FxHashMap<usize, Tensor>,
-    objective_function: fn(&Tensor, &Tensor) -> f64,
+    larger_subtree_nodes: &FxHashMap<usize, LeafTensor>,
+    smaller_subtree_nodes: &FxHashMap<usize, LeafTensor>,
+    objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
 ) -> (usize, f64)
 where
     R: Rng,
@@ -519,7 +520,7 @@ fn shift_node_between_subtrees(
     larger_subtree_id: usize,
     smaller_subtree_id: usize,
     rebalanced_nodes: Vec<usize>,
-    tensor_network: &Tensor,
+    tensor_network: &CompositeTensor,
 ) -> (usize, SimplePath, f64, f64, usize, SimplePath, f64, f64) {
     // Obtain parents of the two subtrees that are being updated.
     let larger_subtree_parent_id = contraction_tree
@@ -626,9 +627,8 @@ mod tests {
         ContractionTree,
     };
     use crate::path;
-    use crate::tensornetwork::tensor::Tensor;
 
-    fn setup_complex() -> (ContractionTree, Tensor) {
+    fn setup_complex() -> (ContractionTree, CompositeTensor) {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -643,13 +643,13 @@ mod tests {
             (10, 5),
         ]);
         let (tensor, contraction_path) = (
-            Tensor::new_composite(vec![
-                Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-                Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-                Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
-                Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+            CompositeTensor::new(vec![
+                LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+                LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+                LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
+                LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
             ]),
             path![(1, 5), (0, 1), (3, 4), (2, 3), (0, 2)],
         );
@@ -726,7 +726,7 @@ mod tests {
         assert_eq!(root.upgrade().unwrap(), ref_root);
     }
 
-    fn custom_weight_function(a: &Tensor, b: &Tensor) -> f64 {
+    fn custom_weight_function(a: &LeafTensor, b: &LeafTensor) -> f64 {
         (a & b).legs().len() as f64
     }
 
@@ -735,13 +735,13 @@ mod tests {
         let bond_dims =
             FxHashMap::from_iter([(0, 2), (1, 1), (2, 3), (3, 5), (4, 3), (5, 8), (6, 7)]);
         let larger_hash = FxHashMap::from_iter([
-            (0, Tensor::new_from_map(vec![0, 1, 2], &bond_dims)),
-            (1, Tensor::new_from_map(vec![1, 2, 3], &bond_dims)),
-            (2, Tensor::new_from_map(vec![3, 4, 5], &bond_dims)),
+            (0, LeafTensor::new_from_map(vec![0, 1, 2], &bond_dims)),
+            (1, LeafTensor::new_from_map(vec![1, 2, 3], &bond_dims)),
+            (2, LeafTensor::new_from_map(vec![3, 4, 5], &bond_dims)),
         ]);
 
         let smaller_hash =
-            FxHashMap::from_iter([(3, Tensor::new_from_map(vec![4, 5, 6], &bond_dims))]);
+            FxHashMap::from_iter([(3, LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims))]);
 
         let ref_balanced_node = 2;
         let (node_id, cost) = find_rebalance_node::<StdRng>(
@@ -759,13 +759,13 @@ mod tests {
         let bond_dims =
             FxHashMap::from_iter([(0, 2), (1, 1), (2, 3), (3, 5), (4, 3), (5, 8), (6, 7)]);
         let larger_hash = FxHashMap::from_iter([
-            (0, Tensor::new_from_map(vec![0, 1, 2], &bond_dims)),
-            (1, Tensor::new_from_map(vec![1, 2, 6], &bond_dims)),
-            (2, Tensor::new_from_map(vec![3, 4, 5], &bond_dims)),
+            (0, LeafTensor::new_from_map(vec![0, 1, 2], &bond_dims)),
+            (1, LeafTensor::new_from_map(vec![1, 2, 6], &bond_dims)),
+            (2, LeafTensor::new_from_map(vec![3, 4, 5], &bond_dims)),
         ]);
 
         let smaller_hash =
-            FxHashMap::from_iter([(3, Tensor::new_from_map(vec![4, 5, 6], &bond_dims))]);
+            FxHashMap::from_iter([(3, LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims))]);
 
         let ref_balanced_node = 1;
         let (node_id, cost) = find_rebalance_node(

--- a/tnc/src/contractionpath/contraction_tree/balancing/balancing_schemes.rs
+++ b/tnc/src/contractionpath/contraction_tree/balancing/balancing_schemes.rs
@@ -5,7 +5,7 @@ use crate::contractionpath::contraction_tree::balancing::{find_rebalance_node, P
 use crate::contractionpath::contraction_tree::{
     populate_leaf_node_tensor_map, populate_subtree_tensor_map, ContractionTree,
 };
-use crate::tensornetwork::tensor::Tensor;
+use crate::tensornetwork::tensor::{CompositeTensor, LeafTensor};
 
 /// The scheme used for greedy balancing of partitions.
 #[derive(Debug, Clone, Copy)]
@@ -84,8 +84,8 @@ pub(super) fn best_worst<R>(
     partition_data: &[PartitionData],
     contraction_tree: &ContractionTree,
     random_balance: &mut Option<(usize, R)>,
-    objective_function: fn(&Tensor, &Tensor) -> f64,
-    tensor: &Tensor,
+    objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
+    tensor: &CompositeTensor,
 ) -> Vec<Shift>
 where
     R: Rng,
@@ -120,8 +120,8 @@ pub(super) fn best_tensor<R>(
     partition_data: &[PartitionData],
     contraction_tree: &ContractionTree,
     random_balance: &mut Option<(usize, R)>,
-    objective_function: fn(&Tensor, &Tensor) -> f64,
-    tensor: &Tensor,
+    objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
+    tensor: &CompositeTensor,
 ) -> Vec<Shift>
 where
     R: Rng,
@@ -163,8 +163,8 @@ pub(super) fn best_tensors<R>(
     partition_data: &[PartitionData],
     contraction_tree: &ContractionTree,
     random_balance: &mut Option<(usize, R)>,
-    objective_function: fn(&Tensor, &Tensor) -> f64,
-    tensor: &Tensor,
+    objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
+    tensor: &CompositeTensor,
 ) -> Vec<Shift>
 where
     R: Rng,
@@ -239,8 +239,8 @@ pub(super) fn tensors_odd<R>(
     partition_data: &[PartitionData],
     contraction_tree: &ContractionTree,
     random_balance: &mut Option<(usize, R)>,
-    objective_function: fn(&Tensor, &Tensor) -> f64,
-    tensor: &Tensor,
+    objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
+    tensor: &CompositeTensor,
 ) -> Vec<Shift>
 where
     R: Rng,
@@ -281,8 +281,8 @@ pub(super) fn tensors_even<R>(
     partition_data: &[PartitionData],
     contraction_tree: &ContractionTree,
     random_balance: &mut Option<(usize, R)>,
-    objective_function: fn(&Tensor, &Tensor) -> f64,
-    tensor: &Tensor,
+    objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
+    tensor: &CompositeTensor,
 ) -> Vec<Shift>
 where
     R: Rng,
@@ -324,8 +324,8 @@ pub(super) fn best_intermediate_tensors<R>(
     partition_data: &[PartitionData],
     contraction_tree: &ContractionTree,
     random_balance: &mut Option<(usize, R)>,
-    objective_function: fn(&Tensor, &Tensor) -> f64,
-    tensor: &Tensor,
+    objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
+    tensor: &CompositeTensor,
     height_limit: Option<usize>,
 ) -> Vec<Shift>
 where
@@ -404,8 +404,8 @@ pub(super) fn intermediate_tensors_odd<R>(
     partition_data: &[PartitionData],
     contraction_tree: &ContractionTree,
     random_balance: &mut Option<(usize, R)>,
-    objective_function: fn(&Tensor, &Tensor) -> f64,
-    tensor: &Tensor,
+    objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
+    tensor: &CompositeTensor,
     height_limit: Option<usize>,
 ) -> Vec<Shift>
 where
@@ -450,8 +450,8 @@ pub(super) fn intermediate_tensors_even<R>(
     partition_data: &[PartitionData],
     contraction_tree: &ContractionTree,
     random_balance: &mut Option<(usize, R)>,
-    objective_function: fn(&Tensor, &Tensor) -> f64,
-    tensor: &Tensor,
+    objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
+    tensor: &CompositeTensor,
     height_limit: Option<usize>,
 ) -> Vec<Shift>
 where
@@ -496,8 +496,8 @@ where
 pub(super) fn tree_tensors_odd(
     partition_data: &[PartitionData],
     contraction_tree: &ContractionTree,
-    objective_function: fn(&Tensor, &Tensor) -> f64,
-    tensor: &Tensor,
+    objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
+    tensor: &CompositeTensor,
     height_limit: usize,
 ) -> Vec<Shift> {
     // Obtain most expensive partition
@@ -549,8 +549,8 @@ pub(super) fn tree_tensors_odd(
 pub(super) fn tree_tensors_even(
     partition_data: &[PartitionData],
     contraction_tree: &ContractionTree,
-    objective_function: fn(&Tensor, &Tensor) -> f64,
-    tensor: &Tensor,
+    objective_function: fn(&LeafTensor, &LeafTensor) -> f64,
+    tensor: &CompositeTensor,
     height_limit: usize,
 ) -> Vec<Shift> {
     let smaller_subtree_id = partition_data.first().unwrap().id;
@@ -613,7 +613,7 @@ mod tests {
     use crate::{
         contractionpath::contraction_tree::{balancing::PartitionData, ContractionTree},
         path,
-        tensornetwork::tensor::Tensor,
+        tensornetwork::tensor::LeafTensor,
     };
 
     fn setup_simple_partition_data() -> Vec<PartitionData> {
@@ -636,27 +636,27 @@ mod tests {
                 flop_cost: 1.,
                 mem_cost: 0.,
                 contraction: Default::default(),
-                local_tensor: Tensor::new_from_map(vec![7, 9, 10], &bond_dims),
+                local_tensor: LeafTensor::new_from_map(vec![7, 9, 10], &bond_dims),
             },
             PartitionData {
                 id: 7,
                 flop_cost: 2.,
                 mem_cost: 0.,
                 contraction: Default::default(),
-                local_tensor: Tensor::new_from_map(vec![0, 1, 5, 7], &bond_dims),
+                local_tensor: LeafTensor::new_from_map(vec![0, 1, 5, 7], &bond_dims),
             },
             PartitionData {
                 id: 14,
                 flop_cost: 3.,
                 mem_cost: 0.,
                 contraction: Default::default(),
-                local_tensor: Tensor::new_from_map(vec![0, 1, 2, 5, 10], &bond_dims),
+                local_tensor: LeafTensor::new_from_map(vec![0, 1, 2, 5, 10], &bond_dims),
             },
         ]
     }
 
     /// Tensor ids in contraction tree included in variable name for easy tracking
-    fn setup_simple() -> (ContractionTree, Tensor) {
+    fn setup_simple() -> (ContractionTree, CompositeTensor) {
         let bond_dims = FxHashMap::from_iter([
             (0, 2),
             (1, 2),
@@ -671,26 +671,26 @@ mod tests {
             (10, 2),
         ]);
 
-        let tensor0 = Tensor::new_from_map(vec![7, 8], &bond_dims);
-        let tensor1 = Tensor::new_from_map(vec![8, 9, 10], &bond_dims);
+        let tensor0 = LeafTensor::new_from_map(vec![7, 8], &bond_dims);
+        let tensor1 = LeafTensor::new_from_map(vec![8, 9, 10], &bond_dims);
 
-        let tensor3 = Tensor::new_from_map(vec![0, 6], &bond_dims);
-        let tensor4 = Tensor::new_from_map(vec![1, 6], &bond_dims);
-        let tensor5 = Tensor::new_from_map(vec![5, 7], &bond_dims);
+        let tensor3 = LeafTensor::new_from_map(vec![0, 6], &bond_dims);
+        let tensor4 = LeafTensor::new_from_map(vec![1, 6], &bond_dims);
+        let tensor5 = LeafTensor::new_from_map(vec![5, 7], &bond_dims);
 
-        let tensor8 = Tensor::new_from_map(vec![0, 1], &bond_dims);
-        let tensor9 = Tensor::new_from_map(vec![2, 3], &bond_dims);
-        let tensor10 = Tensor::new_from_map(vec![3, 4], &bond_dims);
-        let tensor11 = Tensor::new_from_map(vec![4, 5, 10], &bond_dims);
+        let tensor8 = LeafTensor::new_from_map(vec![0, 1], &bond_dims);
+        let tensor9 = LeafTensor::new_from_map(vec![2, 3], &bond_dims);
+        let tensor10 = LeafTensor::new_from_map(vec![3, 4], &bond_dims);
+        let tensor11 = LeafTensor::new_from_map(vec![4, 5, 10], &bond_dims);
 
-        let intermediate_tensor2 = Tensor::new_composite(vec![tensor0, tensor1]);
+        let intermediate_tensor2 = CompositeTensor::new(vec![tensor0, tensor1]);
 
-        let intermediate_tensor7 = Tensor::new_composite(vec![tensor3, tensor4, tensor5]);
+        let intermediate_tensor7 = CompositeTensor::new(vec![tensor3, tensor4, tensor5]);
 
         let intermediate_tensor14 =
-            Tensor::new_composite(vec![tensor8, tensor9, tensor10, tensor11]);
+            CompositeTensor::new(vec![tensor8, tensor9, tensor10, tensor11]);
 
-        let tensor15 = Tensor::new_composite(vec![
+        let tensor15 = CompositeTensor::new(vec![
             intermediate_tensor2,
             intermediate_tensor7,
             intermediate_tensor14,
@@ -712,7 +712,7 @@ mod tests {
         )
     }
 
-    fn custom_cost_function(a: &Tensor, b: &Tensor) -> f64 {
+    fn custom_cost_function(a: &LeafTensor, b: &LeafTensor) -> f64 {
         (a & b).legs().len() as f64
     }
 

--- a/tnc/src/contractionpath/contraction_tree/utils.rs
+++ b/tnc/src/contractionpath/contraction_tree/utils.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         ContractionPath, SimplePath,
     },
-    tensornetwork::tensor::Tensor,
+    tensornetwork::tensor::{CompositeTensor, LeafTensor, TensorList},
 };
 
 /// Identifies the contraction path designated by subtree rooted at `node_id` in
@@ -20,15 +20,18 @@ use crate::{
 pub(super) fn subtree_tensor_network(
     node_id: usize,
     contraction_tree: &ContractionTree,
-    tensor_network: &Tensor,
-) -> (Vec<Tensor>, SimplePath) {
+    tensor_network: &CompositeTensor,
+) -> (Vec<LeafTensor>, SimplePath) {
     let leaf_ids = contraction_tree.leaf_ids(node_id);
     let local_tensors = leaf_ids
         .iter()
         .map(|&id| {
-            tensor_network.nested_tensor(contraction_tree.node(id).tensor_index().as_ref().unwrap())
+            tensor_network
+                .nested_tensor(contraction_tree.node(id).tensor_index().as_ref().unwrap())
+                .clone()
+                .into_leaf()
+                .unwrap()
         })
-        .cloned()
         .collect_vec();
     let local_mapping = leaf_ids
         .iter()
@@ -52,7 +55,7 @@ pub(super) fn subtree_tensor_network(
 pub(super) fn subtree_contraction_path(
     subtree_leaf_nodes: &[usize],
     contraction_tree: &ContractionTree,
-    tensor_network: &Tensor,
+    tensor_network: &CompositeTensor,
 ) -> (SimplePath, SimplePath, f64, f64) {
     // Obtain the flattened list of Tensors corresponding to `indices`. Introduces a new indexing to find the replace contraction path.
     let tensors = subtree_leaf_nodes
@@ -65,7 +68,7 @@ pub(super) fn subtree_contraction_path(
         .collect_vec();
 
     // Obtain tensor network corresponding to subtree
-    let subtree_tensor_network = Tensor::new_composite(tensors);
+    let subtree_tensor_network = CompositeTensor::new(tensors);
 
     let mut opt = Cotengrust::new(OptMethod::Greedy);
     let result = opt.find_path(&subtree_tensor_network);
@@ -90,7 +93,7 @@ pub(super) fn subtree_contraction_path(
 pub(super) fn characterize_partition(
     contraction_tree: &ContractionTree,
     rebalance_depth: usize,
-    tensor_network: &Tensor,
+    tensor_network: &CompositeTensor,
 ) -> Vec<PartitionData> {
     let children = &contraction_tree.partitions()[&rebalance_depth];
 
@@ -102,7 +105,7 @@ pub(super) fn characterize_partition(
                 subtree_tensor_network(*child, contraction_tree, tensor_network);
 
             let (flop_cost, mem_cost) = contract_path_cost(
-                &local_tensors,
+                local_tensors.as_tensors(),
                 &ContractionPath::simple(local_contraction_path.clone()),
                 true,
             );
@@ -111,7 +114,9 @@ pub(super) fn characterize_partition(
                 flop_cost,
                 mem_cost,
                 contraction: local_contraction_path,
-                local_tensor: local_tensors.iter().fold(Tensor::default(), |a, b| &a ^ b),
+                local_tensor: local_tensors
+                    .iter()
+                    .fold(LeafTensor::default(), |a, b| &a ^ b),
             }
         })
         .collect_vec();
@@ -127,9 +132,12 @@ mod tests {
 
     use rustc_hash::FxHashMap;
 
-    use crate::{path, tensornetwork::tensor::EdgeIndex};
+    use crate::{
+        path,
+        tensornetwork::tensor::{EdgeIndex, Tensor},
+    };
 
-    fn setup_complex() -> (Tensor, ContractionPath, FxHashMap<EdgeIndex, u64>) {
+    fn setup_complex() -> (CompositeTensor, ContractionPath, FxHashMap<EdgeIndex, u64>) {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -144,20 +152,20 @@ mod tests {
             (10, 5),
         ]);
         (
-            Tensor::new_composite(vec![
-                Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-                Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-                Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
-                Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+            CompositeTensor::new(vec![
+                LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+                LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+                LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
+                LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
             ]),
             path![(1, 5), (0, 1), (3, 4), (2, 3), (0, 2)],
             bond_dims,
         )
     }
 
-    fn setup_double_nested() -> (Tensor, ContractionPath) {
+    fn setup_double_nested() -> (CompositeTensor, ContractionPath) {
         let bond_dims = FxHashMap::from_iter([
             (0, 1),
             (1, 2),
@@ -173,18 +181,20 @@ mod tests {
             (11, 12),
         ]);
 
-        let t0 = Tensor::new_from_map(vec![4, 3, 2], &bond_dims);
-        let t1 = Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims);
-        let t2 = Tensor::new_from_map(vec![4, 5, 6], &bond_dims);
-        let t3 = Tensor::new_from_map(vec![6, 8, 9], &bond_dims);
-        let t4 = Tensor::new_from_map(vec![5, 1, 0], &bond_dims);
-        let t5 = Tensor::new_from_map(vec![10, 8, 9], &bond_dims);
+        let t0 = LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims);
+        let t1 = LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims);
+        let t2 = LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims);
+        let t3 = LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims);
+        let t4 = LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims);
+        let t5 = LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims);
 
-        let t01 = Tensor::new_composite(vec![t0, t1]);
-        let t012 = Tensor::new_composite(vec![t01, t2]);
-        let t34 = Tensor::new_composite(vec![t3, t4]);
-        let t345 = Tensor::new_composite(vec![t34, t5]);
-        let tensor_network = Tensor::new_composite(vec![t012, t345]);
+        let t01 = CompositeTensor::new(vec![t0, t1]);
+        let t01: Tensor = t01.into();
+        let t012 = CompositeTensor::new(vec![t01, t2.into()]);
+        let t34 = CompositeTensor::new(vec![t3, t4]);
+        let t34: Tensor = t34.into();
+        let t345 = CompositeTensor::new(vec![t34, t5.into()]);
+        let tensor_network = CompositeTensor::new(vec![t012, t345]);
         (
             tensor_network,
             path![
@@ -197,7 +207,7 @@ mod tests {
         )
     }
 
-    fn setup_nested() -> (Tensor, ContractionPath, FxHashMap<EdgeIndex, u64>) {
+    fn setup_nested() -> (CompositeTensor, ContractionPath, FxHashMap<EdgeIndex, u64>) {
         let bond_dims = FxHashMap::from_iter([
             (0, 4),
             (1, 6),
@@ -210,19 +220,19 @@ mod tests {
             (8, 2),
         ]);
 
-        let t0 = Tensor::new_from_map(vec![0, 1], &bond_dims);
-        let t1 = Tensor::new_from_map(vec![0, 2], &bond_dims);
-        let t2 = Tensor::new_from_map(vec![3], &bond_dims);
-        let t3 = Tensor::new_from_map(vec![2, 4], &bond_dims);
-        let t4 = Tensor::new_from_map(vec![1, 3, 5, 8], &bond_dims);
-        let t5 = Tensor::new_from_map(vec![4, 7, 8], &bond_dims);
-        let t6 = Tensor::new_from_map(vec![5, 6, 7], &bond_dims);
-        let t7 = Tensor::new_from_map(vec![6], &bond_dims);
+        let t0 = LeafTensor::new_from_map(vec![0, 1], &bond_dims);
+        let t1 = LeafTensor::new_from_map(vec![0, 2], &bond_dims);
+        let t2 = LeafTensor::new_from_map(vec![3], &bond_dims);
+        let t3 = LeafTensor::new_from_map(vec![2, 4], &bond_dims);
+        let t4 = LeafTensor::new_from_map(vec![1, 3, 5, 8], &bond_dims);
+        let t5 = LeafTensor::new_from_map(vec![4, 7, 8], &bond_dims);
+        let t6 = LeafTensor::new_from_map(vec![5, 6, 7], &bond_dims);
+        let t7 = LeafTensor::new_from_map(vec![6], &bond_dims);
 
-        let t012 = Tensor::new_composite(vec![t0, t1, t2]);
-        let t345 = Tensor::new_composite(vec![t3, t4, t5]);
-        let t67 = Tensor::new_composite(vec![t6, t7]);
-        let tensor_network = Tensor::new_composite(vec![t012, t345, t67]);
+        let t012 = CompositeTensor::new(vec![t0, t1, t2]);
+        let t345 = CompositeTensor::new(vec![t3, t4, t5]);
+        let t67 = CompositeTensor::new(vec![t6, t7]);
+        let tensor_network = CompositeTensor::new(vec![t012, t345, t67]);
         (
             tensor_network,
             path![
@@ -267,12 +277,12 @@ mod tests {
         let (subtree_tensors, contraction_path) =
             subtree_tensor_network(node_id, &contraction_tree, &tensor);
 
-        let tensor0 = Tensor::new_from_map(vec![4, 3, 2], &bond_dims);
-        let tensor1 = Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims);
-        let tensor2 = Tensor::new_from_map(vec![4, 5, 6], &bond_dims);
-        let tensor3 = Tensor::new_from_map(vec![6, 8, 9], &bond_dims);
-        let tensor4 = Tensor::new_from_map(vec![10, 8, 9], &bond_dims);
-        let tensor5 = Tensor::new_from_map(vec![5, 1, 0], &bond_dims);
+        let tensor0 = LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims);
+        let tensor1 = LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims);
+        let tensor2 = LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims);
+        let tensor3 = LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims);
+        let tensor4 = LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims);
+        let tensor5 = LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims);
 
         let subtree7 = vec![tensor0, tensor1, tensor5];
         for (tensor, ref_tensor) in zip(subtree_tensors, subtree7) {
@@ -315,21 +325,21 @@ mod tests {
                 flop_cost: 84., // (0, 1, 2) + (1, 2, 3) = 84
                 mem_cost: 44.,  // (0, 1) + (0, 2) + (0, 1, 2) = 44
                 contraction: vec![(0, 1), (0, 2)],
-                local_tensor: Tensor::new_from_map(vec![1, 2, 3], &bond_dims),
+                local_tensor: LeafTensor::new_from_map(vec![1, 2, 3], &bond_dims),
             },
             PartitionData {
                 id: 9,
                 flop_cost: 3456., // (1, 2, 3, 4, 5, 8) + (1, 2, 3, 4, 5, 7, 8) = 3456
                 mem_cost: 864.,   // (1, 2, 3, 4, 5, 8) + (4, 7, 8) + (1, 2, 3, 5) = 864
                 contraction: vec![(0, 1), (0, 2)],
-                local_tensor: Tensor::new_from_map(vec![2, 1, 3, 5, 7], &bond_dims),
+                local_tensor: LeafTensor::new_from_map(vec![2, 1, 3, 5, 7], &bond_dims),
             },
             PartitionData {
                 id: 12,
                 flop_cost: 140., // (5, 6, 7) = 140
                 mem_cost: 167.,  // (5, 6, 7) + (6) + (5, 7) = 167
                 contraction: vec![(0, 1)],
-                local_tensor: Tensor::new_from_map(vec![5, 7], &bond_dims),
+                local_tensor: LeafTensor::new_from_map(vec![5, 7], &bond_dims),
             },
         ];
         assert_eq!(partition_data, ref_partition_data);

--- a/tnc/src/contractionpath/paths.rs
+++ b/tnc/src/contractionpath/paths.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     contractionpath::{ssa_replace_ordering, ContractionPath},
-    tensornetwork::tensor::Tensor,
+    tensornetwork::tensor::CompositeTensor,
 };
 
 pub mod branchbound;
@@ -24,7 +24,7 @@ pub trait Pathfinder {
     /// Finds a contraction path for the `tensor`.
     ///
     /// Uses `&mut self` to allow for internal state such as caching.
-    fn find_path(&mut self, tensor: &Tensor) -> Self::Result;
+    fn find_path(&mut self, tensor: &CompositeTensor) -> Self::Result;
 }
 
 /// The result of running a contraction [`Pathfinder`].

--- a/tnc/src/contractionpath/paths/branchbound.rs
+++ b/tnc/src/contractionpath/paths/branchbound.rs
@@ -10,7 +10,7 @@ use crate::{
         paths::{BasicContractionPathResult, ContractionPathResult, CostType, Pathfinder},
         ssa_ordering, ContractionPath,
     },
-    tensornetwork::tensor::Tensor,
+    tensornetwork::tensor::{CompositeTensor, LeafTensor},
     utils::traits::HashMapInsertNew,
 };
 
@@ -26,7 +26,7 @@ pub struct BranchBound {
     result_cache: FxHashMap<(usize, usize), usize>,
     flop_cache: FxHashMap<usize, f64>,
     size_cache: FxHashMap<usize, f64>,
-    tensor_cache: FxHashMap<usize, Tensor>,
+    tensor_cache: FxHashMap<usize, LeafTensor>,
 }
 
 impl BranchBound {
@@ -57,7 +57,7 @@ impl BranchBound {
         let flops_12: f64;
         let size_12: f64;
         let k12: usize;
-        let k12_tensor: Tensor;
+        let k12_tensor: LeafTensor;
         let mut current_flops = flops;
         let mut current_size = size;
         // Ensure that larger tensor is always to the left.
@@ -111,7 +111,7 @@ impl BranchBound {
     /// the Python based `opt_einsum` implementation. Found at <https://github.com/dgasmith/opt_einsum>.
     fn branch_iterate(
         &mut self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         path: &[(usize, usize, usize)],
         remaining: &[usize],
         flops: f64,
@@ -171,10 +171,7 @@ impl BranchBound {
 impl Pathfinder for BranchBound {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
-        if tensor.is_leaf() {
-            return BasicContractionPathResult::default();
-        }
+    fn find_path(&mut self, tensor: &CompositeTensor) -> BasicContractionPathResult {
         let tensors = tensor.tensors().clone();
         self.flop_cache.clear();
         self.size_cache.clear();
@@ -184,13 +181,14 @@ impl Pathfinder for BranchBound {
         // Get the initial space requirements for uncontracted tensors
         for (index, mut tensor) in tensors.into_iter().enumerate() {
             // Check that tensor has sub-tensors and doesn't have external legs set
-            if !tensor.tensors().is_empty() && tensor.legs().is_empty() {
+            if let Some(composite) = tensor.as_composite() {
                 let mut bb =
                     BranchBound::new(self.nbranch, self.cutoff_flops_factor, self.minimize);
-                let result = bb.find_path(&tensor);
+                let result = bb.find_path(composite);
                 nested_paths.insert(index, result.ssa_path().clone());
-                tensor = tensor.external_tensor();
+                tensor = composite.external_tensor().into();
             }
+            let tensor = tensor.into_leaf().unwrap();
             self.size_cache
                 .entry(index)
                 .or_insert_with(|| tensor.size());
@@ -219,19 +217,18 @@ mod tests {
 
     use crate::contractionpath::paths::{CostType, Pathfinder};
     use crate::path;
-    use crate::tensornetwork::tensor::Tensor;
 
-    fn setup_simple() -> Tensor {
+    fn setup_simple() -> CompositeTensor {
         let bond_dims =
             FxHashMap::from_iter([(0, 5), (1, 2), (2, 6), (3, 8), (4, 1), (5, 3), (6, 4)]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
         ])
     }
 
-    fn setup_complex() -> Tensor {
+    fn setup_complex() -> CompositeTensor {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -246,13 +243,13 @@ mod tests {
             (10, 5),
             (11, 17),
         ]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-            Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
         ])
     }
 

--- a/tnc/src/contractionpath/paths/cotengrust.rs
+++ b/tnc/src/contractionpath/paths/cotengrust.rs
@@ -9,7 +9,7 @@ use crate::contractionpath::paths::{
     BasicContractionPathResult, ContractionPathResult, Pathfinder,
 };
 use crate::contractionpath::{ssa_replace_ordering, ContractionPath, SimplePath};
-use crate::tensornetwork::tensor::Tensor;
+use crate::tensornetwork::tensor::{CompositeTensor, LeafTensor, TensorType};
 
 /// The optimization method to use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,7 +37,7 @@ impl Cotengrust {
 
     /// Finds a contraction path for a "classical" tensor network, i.e. the inputs
     /// are all leaf tensors.
-    fn optimize_single(&self, inputs: &[Tensor], output: &Tensor) -> SimplePath {
+    fn optimize_single(&self, inputs: &[LeafTensor], output: &LeafTensor) -> SimplePath {
         // Check if the inputs are empty (cotengrust does not handle this gracefully)
         if inputs.is_empty() {
             return SimplePath::default();
@@ -93,8 +93,8 @@ impl Cotengrust {
 
 /// Converts tensor leg inputs to chars. Creates new inputs, outputs and size_dict that can be fed to Cotengra.
 fn tensor_legs_to_digit(
-    inputs: &[Tensor],
-    output: &Tensor,
+    inputs: &[LeafTensor],
+    output: &LeafTensor,
 ) -> (Vec<Vec<char>>, Vec<char>, FxHashMap<char, f32>) {
     fn leg_to_char(leg: usize) -> char {
         char::from_u32(leg.try_into().unwrap()).unwrap()
@@ -106,9 +106,9 @@ fn tensor_legs_to_digit(
     for (tensor, labels) in zip(inputs, new_inputs.iter_mut()) {
         labels.reserve_exact(tensor.legs().len());
         for (leg, dim) in tensor.edges() {
-            let character = leg_to_char(*leg);
+            let character = leg_to_char(leg);
             labels.push(character);
-            new_size_dict.insert(character, *dim as f32);
+            new_size_dict.insert(character, dim as f32);
         }
     }
     (new_inputs, new_output, new_size_dict)
@@ -117,21 +117,28 @@ fn tensor_legs_to_digit(
 impl Pathfinder for Cotengrust {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
+    fn find_path(&mut self, tensor: &CompositeTensor) -> BasicContractionPathResult {
         // Handle nested tensors first
         let mut nested_paths = FxHashMap::default();
-        let mut inputs = tensor.tensors().clone();
-        for (index, input_tensor) in inputs.iter_mut().enumerate() {
-            if input_tensor.is_composite() {
-                let result = self.find_path(input_tensor);
-                nested_paths.insert(index, result.ssa_path().clone());
-                *input_tensor = input_tensor.external_tensor();
-            }
-        }
+        let leaves = tensor
+            .tensors()
+            .iter()
+            .enumerate()
+            .map(|(index, t)| match t.kind() {
+                TensorType::Composite => {
+                    let composite = t.as_composite().unwrap();
+                    let mut ct = Cotengrust::new(self.opt_method);
+                    let result = ct.find_path(composite);
+                    nested_paths.insert(index, result.ssa_path().clone());
+                    composite.external_tensor()
+                }
+                TensorType::Leaf => t.clone().into_leaf().unwrap(),
+            })
+            .collect_vec();
 
         // Now handle the outer tensor
         let external_tensor = tensor.external_tensor();
-        let outer_path = self.optimize_single(&inputs, &external_tensor);
+        let outer_path = self.optimize_single(&leaves, &external_tensor);
         let best_path = ContractionPath {
             nested: nested_paths,
             toplevel: outer_path,
@@ -154,17 +161,17 @@ mod tests {
 
     use crate::path;
 
-    fn setup_simple() -> Tensor {
+    fn setup_simple() -> CompositeTensor {
         let bond_dims =
             FxHashMap::from_iter([(0, 5), (1, 2), (2, 6), (3, 8), (4, 1), (5, 3), (6, 4)]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
         ])
     }
 
-    fn setup_complex() -> Tensor {
+    fn setup_complex() -> CompositeTensor {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -179,43 +186,43 @@ mod tests {
             (10, 5),
             (11, 17),
         ]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-            Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
         ])
     }
 
-    fn setup_simple_inner_product() -> Tensor {
+    fn setup_simple_inner_product() -> CompositeTensor {
         let bond_dims =
             FxHashMap::from_iter([(0, 5), (1, 2), (2, 6), (3, 8), (4, 1), (5, 3), (6, 4)]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 5], &bond_dims),
-            Tensor::new_from_map(vec![1, 6], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 5], &bond_dims),
+            LeafTensor::new_from_map(vec![1, 6], &bond_dims),
         ])
     }
 
-    fn setup_simple_outer_product() -> Tensor {
+    fn setup_simple_outer_product() -> CompositeTensor {
         let bond_dims = FxHashMap::from_iter([(0, 3), (1, 2), (2, 2)]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![0], &bond_dims),
-            Tensor::new_from_map(vec![1], &bond_dims),
-            Tensor::new_from_map(vec![2], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![0], &bond_dims),
+            LeafTensor::new_from_map(vec![1], &bond_dims),
+            LeafTensor::new_from_map(vec![2], &bond_dims),
         ])
     }
 
-    fn setup_complex_outer_product() -> Tensor {
+    fn setup_complex_outer_product() -> CompositeTensor {
         let bond_dims = FxHashMap::from_iter([(0, 5), (1, 4)]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![0], &bond_dims),
-            Tensor::new_from_map(vec![0], &bond_dims),
-            Tensor::new_from_map(vec![1], &bond_dims),
-            Tensor::new_from_map(vec![1], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![0], &bond_dims),
+            LeafTensor::new_from_map(vec![0], &bond_dims),
+            LeafTensor::new_from_map(vec![1], &bond_dims),
+            LeafTensor::new_from_map(vec![1], &bond_dims),
         ])
     }
 

--- a/tnc/src/contractionpath/paths/hyperoptimization.rs
+++ b/tnc/src/contractionpath/paths/hyperoptimization.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use rustc_hash::FxHashMap;
 use rustengra::hyper::cotengra_hyperoptimizer;
 
@@ -8,7 +7,7 @@ use crate::{
         paths::{BasicContractionPathResult, ContractionPathResult, CostType, Pathfinder},
         ssa_replace_ordering, ContractionPath,
     },
-    tensornetwork::tensor::Tensor,
+    tensornetwork::tensor::{CompositeTensor, LeafTensor, TensorType},
 };
 
 pub use rustengra::hyper::HyperOptions;
@@ -34,36 +33,39 @@ impl Hyperoptimizer {
 impl Pathfinder for Hyperoptimizer {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
+    fn find_path(&mut self, tensor: &CompositeTensor) -> BasicContractionPathResult {
         // Handle nested tensors first
         let mut nested_paths = FxHashMap::default();
-        let inputs = tensor
-            .tensors()
-            .iter()
-            .enumerate()
-            .map(|(index, tensor)| {
-                if tensor.is_composite() {
-                    let result = self.find_path(tensor);
-                    nested_paths.insert(index, result.ssa_path().clone());
-                    tensor.external_tensor().legs
-                } else {
-                    tensor.legs.clone()
-                }
-            })
-            .collect_vec();
+        let mut inputs = Vec::with_capacity(tensor.len());
+        let mut output = LeafTensor::default();
+        let mut size_dict = FxHashMap::default();
 
-        let outputs = tensor.external_tensor();
-        let size_dict = tensor.tensors().iter().map(Tensor::edges).fold(
-            FxHashMap::default(),
-            |mut acc, edges| {
-                acc.extend(edges);
-                acc
-            },
-        );
+        for (index, tensor) in tensor.tensors().iter().enumerate() {
+            match tensor.kind() {
+                TensorType::Composite => {
+                    // Find a path for the nested tensors
+                    let composite = tensor.as_composite().unwrap();
+                    let result = self.find_path(composite);
+                    nested_paths.insert(index, result.ssa_path().clone());
+
+                    // Get the outer tensor after contraction
+                    let leaf = composite.external_tensor();
+                    size_dict.extend(leaf.edges());
+                    output ^= &leaf;
+                    inputs.push(leaf.into_legs());
+                }
+                TensorType::Leaf => {
+                    let leaf = tensor.as_leaf().unwrap();
+                    size_dict.extend(leaf.edges());
+                    output ^= leaf;
+                    inputs.push(leaf.legs().clone());
+                }
+            }
+        }
 
         let (ssa_path, _) = cotengra_hyperoptimizer(
             &inputs,
-            outputs.legs(),
+            output.legs(),
             &size_dict,
             "kahypar",
             &self.hyper_options,
@@ -95,20 +97,19 @@ mod tests {
     use crate::{
         contractionpath::paths::{CostType, Pathfinder},
         path,
-        tensornetwork::tensor::Tensor,
     };
 
-    fn setup_simple() -> Tensor {
+    fn setup_simple() -> CompositeTensor {
         let bond_dims =
             FxHashMap::from_iter([(0, 5), (1, 2), (2, 6), (3, 8), (4, 1), (5, 3), (6, 4)]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
         ])
     }
 
-    fn setup_complex() -> Tensor {
+    fn setup_complex() -> CompositeTensor {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -123,13 +124,13 @@ mod tests {
             (10, 5),
             (11, 17),
         ]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-            Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
         ])
     }
 

--- a/tnc/src/contractionpath/paths/tree_annealing.rs
+++ b/tnc/src/contractionpath/paths/tree_annealing.rs
@@ -8,7 +8,7 @@ use crate::{
         paths::{BasicContractionPathResult, CostType, Pathfinder},
         ssa_replace_ordering, ContractionPath,
     },
-    tensornetwork::tensor::Tensor,
+    tensornetwork::tensor::CompositeTensor,
 };
 
 /// Creates an interface to `rustengra` an interface to access `Cotengra` methods in
@@ -43,21 +43,22 @@ impl TreeAnnealing {
 impl Pathfinder for TreeAnnealing {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
+    fn find_path(&mut self, tensor: &CompositeTensor) -> BasicContractionPathResult {
         // Map tensors to legs
         let inputs = tensor
             .tensors()
             .iter()
-            .map(|tensor| tensor.legs().clone())
+            .map(|tensor| tensor.as_leaf().unwrap().legs().clone())
             .collect_vec();
         let outputs = tensor.external_tensor();
-        let size_dict = tensor.tensors().iter().map(Tensor::edges).fold(
-            FxHashMap::default(),
-            |mut acc, edges| {
+        let size_dict = tensor
+            .tensors()
+            .iter()
+            .map(|tensor| tensor.as_leaf().unwrap().edges())
+            .fold(FxHashMap::default(), |mut acc, edges| {
                 acc.extend(edges);
                 acc
-            },
-        );
+            });
 
         let best_path = cotengra_sa_tree(
             &inputs,
@@ -91,20 +92,20 @@ mod tests {
     use crate::{
         contractionpath::paths::{CostType, Pathfinder},
         path,
-        tensornetwork::tensor::Tensor,
+        tensornetwork::tensor::LeafTensor,
     };
 
-    fn setup_simple() -> Tensor {
+    fn setup_simple() -> CompositeTensor {
         let bond_dims =
             FxHashMap::from_iter([(0, 5), (1, 2), (2, 6), (3, 8), (4, 1), (5, 3), (6, 4)]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
         ])
     }
 
-    fn setup_complex() -> Tensor {
+    fn setup_complex() -> CompositeTensor {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -119,13 +120,13 @@ mod tests {
             (10, 5),
             (11, 17),
         ]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-            Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
         ])
     }
 

--- a/tnc/src/contractionpath/paths/tree_reconfiguration.rs
+++ b/tnc/src/contractionpath/paths/tree_reconfiguration.rs
@@ -8,7 +8,7 @@ use crate::{
         paths::{BasicContractionPathResult, CostType, Pathfinder},
         ssa_replace_ordering, ContractionPath,
     },
-    tensornetwork::tensor::Tensor,
+    tensornetwork::tensor::CompositeTensor,
 };
 
 /// Creates an interface to `rustengra` an interface to access `Cotengra` methods in
@@ -35,21 +35,22 @@ impl TreeReconfigure {
 impl Pathfinder for TreeReconfigure {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
+    fn find_path(&mut self, tensor: &CompositeTensor) -> BasicContractionPathResult {
         // Map tensors to legs
         let inputs = tensor
             .tensors()
             .iter()
-            .map(|tensor| tensor.legs().clone())
+            .map(|tensor| tensor.as_leaf().unwrap().legs().clone())
             .collect_vec();
         let outputs = tensor.external_tensor();
-        let size_dict = tensor.tensors().iter().map(Tensor::edges).fold(
-            FxHashMap::default(),
-            |mut acc, edges| {
+        let size_dict = tensor
+            .tensors()
+            .iter()
+            .map(|tensor| tensor.as_leaf().unwrap().edges())
+            .fold(FxHashMap::default(), |mut acc, edges| {
                 acc.extend(edges);
                 acc
-            },
-        );
+            });
 
         let best_path =
             cotengra_optimized_greedy(&inputs, outputs.legs(), &size_dict, self.subtree_size)
@@ -77,20 +78,20 @@ mod tests {
     use crate::{
         contractionpath::paths::{CostType, Pathfinder},
         path,
-        tensornetwork::tensor::Tensor,
+        tensornetwork::tensor::LeafTensor,
     };
 
-    fn setup_simple() -> Tensor {
+    fn setup_simple() -> CompositeTensor {
         let bond_dims =
             FxHashMap::from_iter([(0, 5), (1, 2), (2, 6), (3, 8), (4, 1), (5, 3), (6, 4)]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
         ])
     }
 
-    fn setup_complex() -> Tensor {
+    fn setup_complex() -> CompositeTensor {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -105,13 +106,13 @@ mod tests {
             (10, 5),
             (11, 17),
         ]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-            Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
         ])
     }
 

--- a/tnc/src/contractionpath/paths/tree_tempering.rs
+++ b/tnc/src/contractionpath/paths/tree_tempering.rs
@@ -8,7 +8,7 @@ use crate::{
         paths::{BasicContractionPathResult, CostType, Pathfinder},
         ssa_replace_ordering, ContractionPath,
     },
-    tensornetwork::tensor::Tensor,
+    tensornetwork::tensor::CompositeTensor,
 };
 
 /// Creates an interface to `rustengra` an interface to access `Cotengra` methods in
@@ -33,21 +33,22 @@ impl TreeTempering {
 impl Pathfinder for TreeTempering {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
+    fn find_path(&mut self, tensor: &CompositeTensor) -> BasicContractionPathResult {
         // Map tensors to legs
         let inputs = tensor
             .tensors()
             .iter()
-            .map(|tensor| tensor.legs().clone())
+            .map(|tensor| tensor.as_leaf().unwrap().legs().clone())
             .collect_vec();
         let outputs = tensor.external_tensor();
-        let size_dict = tensor.tensors().iter().map(Tensor::edges).fold(
-            FxHashMap::default(),
-            |mut acc, edges| {
+        let size_dict = tensor
+            .tensors()
+            .iter()
+            .map(|tensor| tensor.as_leaf().unwrap().edges())
+            .fold(FxHashMap::default(), |mut acc, edges| {
                 acc.extend(edges);
                 acc
-            },
-        );
+            });
 
         let best_path =
             cotengra_tree_tempering(&inputs, outputs.legs(), self.numiter, &size_dict, self.seed)
@@ -75,20 +76,20 @@ mod tests {
     use crate::{
         contractionpath::paths::{CostType, Pathfinder},
         path,
-        tensornetwork::tensor::Tensor,
+        tensornetwork::tensor::LeafTensor,
     };
 
-    fn setup_simple() -> Tensor {
+    fn setup_simple() -> CompositeTensor {
         let bond_dims =
             FxHashMap::from_iter([(0, 5), (1, 2), (2, 6), (3, 8), (4, 1), (5, 3), (6, 4)]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
         ])
     }
 
-    fn setup_complex() -> Tensor {
+    fn setup_complex() -> CompositeTensor {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -103,13 +104,13 @@ mod tests {
             (10, 5),
             (11, 17),
         ]);
-        Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-            Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+        CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+            LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
         ])
     }
 

--- a/tnc/src/contractionpath/paths/weighted_branchbound.rs
+++ b/tnc/src/contractionpath/paths/weighted_branchbound.rs
@@ -10,7 +10,7 @@ use crate::{
         paths::{BasicContractionPathResult, ContractionPathResult, CostType, Pathfinder},
         ssa_ordering, ContractionPath,
     },
-    tensornetwork::tensor::Tensor,
+    tensornetwork::tensor::{CompositeTensor, LeafTensor},
     utils::traits::HashMapInsertNew,
 };
 
@@ -26,7 +26,7 @@ pub struct WeightedBranchBound {
     largest_latency: f64,
     result_cache: FxHashMap<(usize, usize), (usize, f64, f64)>,
     comm_cache: FxHashMap<usize, f64>,
-    tensor_cache: FxHashMap<usize, Tensor>,
+    tensor_cache: FxHashMap<usize, LeafTensor>,
 }
 
 impl WeightedBranchBound {
@@ -108,7 +108,7 @@ impl WeightedBranchBound {
     /// the Python based `opt_einsum` implementation. Found at <https://github.com/dgasmith/opt_einsum>.
     fn branch_iterate(
         &mut self,
-        tensor: &Tensor,
+        tensor: &CompositeTensor,
         path: &[(usize, usize, usize)],
         remaining: &[usize],
         flops: f64,
@@ -169,10 +169,7 @@ impl WeightedBranchBound {
 impl Pathfinder for WeightedBranchBound {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
-        if tensor.is_leaf() {
-            return BasicContractionPathResult::default();
-        }
+    fn find_path(&mut self, tensor: &CompositeTensor) -> BasicContractionPathResult {
         let tensors = tensor.tensors().clone();
         self.result_cache.clear();
         self.tensor_cache.clear();
@@ -186,17 +183,18 @@ impl Pathfinder for WeightedBranchBound {
         // Get the initial space requirements for uncontracted tensors
         for (index, mut tensor) in tensors.into_iter().enumerate() {
             // Check that tensor has sub-tensors and doesn't have external legs set
-            if tensor.is_composite() && tensor.legs().is_empty() {
+            if let Some(composite) = tensor.as_composite() {
                 let mut bb = WeightedBranchBound::new(
                     self.nbranch,
                     self.cutoff_flops_factor,
                     self.comm_cache.clone(),
                     self.minimize,
                 );
-                let result = bb.find_path(&tensor);
+                let result = bb.find_path(composite);
                 nested_paths.insert(index, result.ssa_path().clone());
-                tensor = tensor.external_tensor();
+                tensor = composite.external_tensor().into();
             }
+            let tensor = tensor.into_leaf().unwrap();
             self.tensor_cache.insert_new(index, tensor);
         }
         let remaining = (0..tensor.tensors().len()).collect_vec();
@@ -222,22 +220,21 @@ mod tests {
     use crate::contractionpath::paths::CostType;
     use crate::contractionpath::paths::Pathfinder;
     use crate::path;
-    use crate::tensornetwork::tensor::Tensor;
 
-    fn setup_simple() -> (Tensor, FxHashMap<usize, f64>) {
+    fn setup_simple() -> (CompositeTensor, FxHashMap<usize, f64>) {
         let bond_dims =
             FxHashMap::from_iter([(0, 5), (1, 2), (2, 6), (3, 8), (4, 1), (5, 3), (6, 4)]);
         (
-            Tensor::new_composite(vec![
-                Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
+            CompositeTensor::new(vec![
+                LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
             ]),
             FxHashMap::from_iter([(0, 20.), (1, 40.), (2, 85.)]),
         )
     }
 
-    fn setup_complex() -> (Tensor, FxHashMap<usize, f64>) {
+    fn setup_complex() -> (CompositeTensor, FxHashMap<usize, f64>) {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -253,13 +250,13 @@ mod tests {
             (11, 17),
         ]);
         (
-            Tensor::new_composite(vec![
-                Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-                Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-                Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
-                Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+            CompositeTensor::new(vec![
+                LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+                LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+                LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
+                LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
             ]),
             FxHashMap::from_iter([(0, 120.), (1, 0.), (2, 15.), (3, 15.), (4, 85.), (5, 15.)]),
         )

--- a/tnc/src/contractionpath/repartitioning.rs
+++ b/tnc/src/contractionpath/repartitioning.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         ContractionPath,
     },
-    tensornetwork::{partitioning::partition_tensor_network, tensor::Tensor},
+    tensornetwork::{partitioning::partition_tensor_network, tensor::CompositeTensor},
 };
 
 pub mod genetic;
@@ -23,11 +23,11 @@ pub mod simulated_annealing;
 /// Given a `tensor` and a `partitioning` for it, this constructs the partitioned
 /// tensor and finds a contraction path for it.
 pub fn compute_solution<R>(
-    tensor: &Tensor,
+    tensor: &CompositeTensor,
     partitioning: &[usize],
     communication_scheme: CommunicationScheme,
     rng: Option<&mut R>,
-) -> (Tensor, ContractionPath, f64, f64)
+) -> (CompositeTensor, ContractionPath, f64, f64)
 where
     R: Rng,
 {
@@ -43,8 +43,8 @@ where
     let mut latency_map =
         FxHashMap::from_iter((0..partitioned_tn.tensors().len()).map(|i| (i, 0.0)));
     for (i, local_path) in &path.nested {
-        let (local_cost, _) =
-            contract_path_cost(partitioned_tn.tensor(*i).tensors(), local_path, true);
+        let composite = partitioned_tn.tensor(*i).as_composite().unwrap().tensors();
+        let (local_cost, _) = contract_path_cost(composite, local_path, true);
         latency_map.insert(*i, local_cost);
     }
 
@@ -52,7 +52,7 @@ where
     let children_tensors = partitioned_tn
         .tensors()
         .iter()
-        .map(Tensor::external_tensor)
+        .map(|composite| composite.as_composite().unwrap().external_tensor())
         .collect_vec();
     let communication_path =
         communication_scheme.communication_path(&children_tensors, &latency_map, rng);

--- a/tnc/src/contractionpath/repartitioning/genetic.rs
+++ b/tnc/src/contractionpath/repartitioning/genetic.rs
@@ -17,12 +17,12 @@ use crate::{
         contraction_cost::{compute_memory_requirements, contract_size_tensors_bytes},
         repartitioning::compute_solution,
     },
-    tensornetwork::tensor::Tensor,
+    tensornetwork::tensor::CompositeTensor,
 };
 
 #[derive(Clone, Debug)]
 struct PartitioningFitness<'a> {
-    tensor: &'a Tensor,
+    tensor: &'a CompositeTensor,
     communication_scheme: CommunicationScheme,
     memory_limit: Option<f64>,
 }
@@ -65,7 +65,7 @@ impl Fitness for PartitioningFitness<'_> {
 /// Balances partitions using a genetic algorithm. Finds the partitioning that reduces
 /// the total contraction cost.
 pub fn balance_partitions(
-    tensor: &Tensor,
+    tensor: &CompositeTensor,
     num_partitions: usize,
     initial_partitioning: &[usize],
     communication_scheme: CommunicationScheme,
@@ -113,15 +113,17 @@ pub fn balance_partitions(
 
 #[cfg(test)]
 mod tests {
+    use crate::tensornetwork::tensor::LeafTensor;
+
     use super::*;
 
     #[test]
     fn small_partitioning() {
-        let t1 = Tensor::new_from_const(vec![0, 1], 2);
-        let t2 = Tensor::new_from_const(vec![2, 3], 2);
-        let t3 = Tensor::new_from_const(vec![0, 1, 4], 2);
-        let t4 = Tensor::new_from_const(vec![2, 3, 4], 2);
-        let tn = Tensor::new_composite(vec![t1, t2, t3, t4]);
+        let t1 = LeafTensor::new_from_const(vec![0, 1], 2);
+        let t2 = LeafTensor::new_from_const(vec![2, 3], 2);
+        let t3 = LeafTensor::new_from_const(vec![0, 1, 4], 2);
+        let t4 = LeafTensor::new_from_const(vec![2, 3, 4], 2);
+        let tn = CompositeTensor::new(vec![t1, t2, t3, t4]);
         let initial_partitioning = vec![0, 0, 1, 1];
 
         let (partitioning, _) = balance_partitions(

--- a/tnc/src/contractionpath/repartitioning/simulated_annealing.rs
+++ b/tnc/src/contractionpath/repartitioning/simulated_annealing.rs
@@ -22,7 +22,10 @@ use crate::{
         repartitioning::compute_solution,
         SimplePath,
     },
-    tensornetwork::{partitioning::partition_tensor_network, tensor::Tensor},
+    tensornetwork::{
+        partitioning::partition_tensor_network,
+        tensor::{CompositeTensor, LeafTensor},
+    },
 };
 
 type ScoreType = NotNan<f64>;
@@ -166,7 +169,7 @@ impl SimulatedAnnealingOptimizer {
 
 /// Common evaluation method for all simulated annealing methods.
 fn evaluate_partitioning<R>(
-    tensor: &Tensor,
+    tensor: &CompositeTensor,
     partitioning: &[usize],
     communication_scheme: CommunicationScheme,
     memory_limit: Option<f64>,
@@ -197,7 +200,7 @@ where
 
 /// A simulated annealing model that moves a random tensor between random partitions.
 pub struct NaivePartitioningModel<'a> {
-    pub tensor: &'a Tensor,
+    pub tensor: &'a CompositeTensor,
     pub num_partitions: usize,
     pub communication_scheme: CommunicationScheme,
     pub memory_limit: Option<f64>,
@@ -236,7 +239,7 @@ impl OptModel for NaivePartitioningModel<'_> {
 
 /// A simulated annealing model that moves a random subtree between random partitions.
 pub struct NaiveIntermediatePartitioningModel<'a> {
-    pub tensor: &'a Tensor,
+    pub tensor: &'a CompositeTensor,
     pub num_partitions: usize,
     pub communication_scheme: CommunicationScheme,
     pub memory_limit: Option<f64>,
@@ -312,8 +315,8 @@ impl OptModel for NaiveIntermediatePartitioningModel<'_> {
         }
 
         // Recompute the contraction path for both partitions
-        let mut from_tensor = Tensor::default();
-        let mut to_tensor = Tensor::default();
+        let mut from_tensor = CompositeTensor::default();
+        let mut to_tensor = CompositeTensor::default();
         for (partition_index, tensor) in zip(&partitioning, self.tensor.tensors()) {
             if *partition_index == source_partition {
                 from_tensor.push_tensor(tensor.clone());
@@ -349,13 +352,13 @@ impl OptModel for NaiveIntermediatePartitioningModel<'_> {
 /// A simulated annealing model that moves a random tensor to the partition that
 /// maximizes memory reduction.
 pub struct LeafPartitioningModel<'a> {
-    pub tensor: &'a Tensor,
+    pub tensor: &'a CompositeTensor,
     pub communication_scheme: CommunicationScheme,
     pub memory_limit: Option<f64>,
 }
 
 impl OptModel for LeafPartitioningModel<'_> {
-    type SolutionType = (Vec<usize>, Vec<Tensor>);
+    type SolutionType = (Vec<usize>, Vec<LeafTensor>);
 
     fn generate_trial_solution<R: Rng>(
         &self,
@@ -364,7 +367,7 @@ impl OptModel for LeafPartitioningModel<'_> {
     ) -> Self::SolutionType {
         let (mut partitioning, mut partition_tensors) = current_solution;
         let tensor_index = rng.random_range(0..partitioning.len());
-        let shifted_tensor = self.tensor.tensor(tensor_index);
+        let shifted_tensor = self.tensor.tensor(tensor_index).as_leaf().unwrap();
         let source_partition = partitioning[tensor_index];
 
         let (new_partition, _) = partition_tensors
@@ -404,7 +407,7 @@ impl OptModel for LeafPartitioningModel<'_> {
 /// A simulated annealing model that moves a random subtree to the partition that
 /// maximizes memory reduction.
 pub struct IntermediatePartitioningModel<'a> {
-    pub tensor: &'a Tensor,
+    pub tensor: &'a CompositeTensor,
     pub communication_scheme: CommunicationScheme,
     pub memory_limit: Option<f64>,
 }
@@ -421,7 +424,7 @@ impl IntermediatePartitioningModel<'_> {
         let partition_tensors = partitioned_tn
             .tensors()
             .iter()
-            .map(Tensor::external_tensor)
+            .map(|t| t.as_composite().unwrap().external_tensor())
             .collect_vec();
 
         let contraction_paths = initial_contraction_paths.unwrap_or_else(|| {
@@ -432,7 +435,7 @@ impl IntermediatePartitioningModel<'_> {
                 .map(|t| {
                     // Find path for this partition
                     let mut opt = Cotengrust::new(OptMethod::Greedy);
-                    let result = opt.find_path(t);
+                    let result = opt.find_path(t.as_composite().unwrap());
                     let path = result.replace_path();
                     path.into_simple()
                 })
@@ -449,7 +452,7 @@ impl IntermediatePartitioningModel<'_> {
 }
 
 impl OptModel for IntermediatePartitioningModel<'_> {
-    type SolutionType = (Vec<usize>, Vec<Tensor>, Vec<SimplePath>);
+    type SolutionType = (Vec<usize>, Vec<LeafTensor>, Vec<SimplePath>);
 
     fn generate_trial_solution<R: Rng>(
         &self,
@@ -492,7 +495,7 @@ impl OptModel for IntermediatePartitioningModel<'_> {
             }
         }
 
-        let mut shifted_tensor = Tensor::default();
+        let mut shifted_tensor = LeafTensor::default();
         let mut shifted_indices = Vec::with_capacity(tensor_leaves.len());
         for (partition_tensor_index, (i, _partition)) in partitioning
             .iter()
@@ -501,7 +504,7 @@ impl OptModel for IntermediatePartitioningModel<'_> {
             .enumerate()
         {
             if tensor_leaves.contains(&partition_tensor_index) {
-                shifted_tensor ^= self.tensor.tensor(i);
+                shifted_tensor ^= self.tensor.tensor(i).as_leaf().unwrap();
                 shifted_indices.push(i);
             }
         }
@@ -535,8 +538,8 @@ impl OptModel for IntermediatePartitioningModel<'_> {
         partition_tensors[target_partition] ^= &shifted_tensor;
 
         // Recompute the contraction path for both partitions
-        let mut from_tensor = Tensor::default();
-        let mut to_tensor = Tensor::default();
+        let mut from_tensor = CompositeTensor::default();
+        let mut to_tensor = CompositeTensor::default();
         for (partition_index, tensor) in zip(&partitioning, self.tensor.tensors()) {
             if *partition_index == source_partition {
                 from_tensor.push_tensor(tensor.clone());
@@ -607,15 +610,15 @@ mod tests {
 
     #[test]
     fn small_leaf_partitioning() {
-        let t1 = Tensor::new_from_const(vec![0, 1], 2);
-        let t2 = Tensor::new_from_const(vec![2, 3], 2);
-        let t3 = Tensor::new_from_const(vec![0, 1, 4], 2);
-        let t4 = Tensor::new_from_const(vec![2, 3, 4], 2);
-        let tn = Tensor::new_composite(vec![t1.clone(), t2.clone(), t3.clone(), t4.clone()]);
-        let tn1 = Tensor::new_composite(vec![t1, t2]);
-        let tn2 = Tensor::new_composite(vec![t3, t4]);
+        let t1 = LeafTensor::new_from_const(vec![0, 1], 2);
+        let t2 = LeafTensor::new_from_const(vec![2, 3], 2);
+        let t3 = LeafTensor::new_from_const(vec![0, 1, 4], 2);
+        let t4 = LeafTensor::new_from_const(vec![2, 3, 4], 2);
+        let tn = CompositeTensor::new(vec![t1.clone(), t2.clone(), t3.clone(), t4.clone()]);
+        let tn1 = CompositeTensor::new(vec![t1, t2]);
+        let tn2 = CompositeTensor::new(vec![t3, t4]);
         let initial_partitioning = vec![0, 0, 1, 1];
-        let initial_partitions = vec![tn1, tn2];
+        let initial_partitions = vec![tn1.external_tensor(), tn2.external_tensor()];
         let mut rng = StdRng::seed_from_u64(42);
 
         let ((partitioning, _partitions), _) = balance_partitions(

--- a/tnc/src/io/hdf5.rs
+++ b/tnc/src/io/hdf5.rs
@@ -19,11 +19,11 @@ use std::path::Path;
 use hdf5_metno::{File, Result};
 use num_complex::Complex64;
 
-use crate::tensornetwork::tensor::Tensor;
+use crate::tensornetwork::tensor::{CompositeTensor, LeafTensor};
 use crate::tensornetwork::tensordata::{DataTensor, TensorData};
 
 /// Loads a tensor network from a HDF5 file.
-pub fn load_tensor<P>(filename: P) -> Result<Tensor>
+pub fn load_tensor<P>(filename: P) -> Result<CompositeTensor>
 where
     P: AsRef<Path>,
 {
@@ -49,17 +49,18 @@ where
     write_data(&file, tensor)
 }
 
-fn read_tensor(file: &File) -> Result<Tensor> {
+fn read_tensor(file: &File) -> Result<CompositeTensor> {
     let gr = file.group("/tensors")?;
     let tensor_names = gr.member_names()?;
 
-    // Outuput tensor is always labelled as -1
-    let out_tensor = gr.dataset("-1")?;
-    let out_tensor_bids = out_tensor.attr("bids")?;
-    let out_bond_ids = out_tensor_bids.read_1d::<usize>()?;
+    // We don't track external legs explicitly, hence the following is commented out
+    // // Output tensor is always labelled as -1
+    // let out_tensor = gr.dataset("-1")?;
+    // let out_tensor_bids = out_tensor.attr("bids")?;
+    // let out_bond_ids = out_tensor_bids.read_1d::<usize>()?;
 
-    let mut new_tensor_network = Tensor::default();
-
+    let mut new_tensor_network = CompositeTensor::default();
+    new_tensor_network.reserve(tensor_names.len());
     for tensor_name in tensor_names {
         if tensor_name == "-1" {
             continue;
@@ -69,11 +70,10 @@ fn read_tensor(file: &File) -> Result<Tensor> {
         let tensor_dataset = gr.dataset(&tensor_name).unwrap().read_dyn::<Complex64>()?;
         let tensor_shape = tensor_dataset.shape();
         let bond_dims = tensor_shape.iter().map(|s| *s as u64).collect();
-        let mut new_tensor = Tensor::new(bond_ids.to_vec(), bond_dims);
+        let mut new_tensor = LeafTensor::new(bond_ids.to_vec(), bond_dims);
         new_tensor.set_tensor_data(TensorData::Matrix(tensor_dataset));
         new_tensor_network.push_tensor(new_tensor);
     }
-    new_tensor_network.set_legs(out_bond_ids.to_vec());
 
     Ok(new_tensor_network)
 }
@@ -111,7 +111,6 @@ mod tests {
         rng,
     };
 
-    use crate::tensornetwork::tensor::Tensor;
     use crate::tensornetwork::tensordata::TensorData;
 
     /// Creates a new HDF5 file in memory.
@@ -198,8 +197,7 @@ mod tests {
         let file = create_hdf5_tensor().unwrap();
         let tensor = read_tensor(&file).unwrap();
 
-        let mut ref_tn = Tensor::default();
-        let mut ref_tensor = Tensor::new(vec![0, 1], vec![2, 2]);
+        let mut ref_tensor = LeafTensor::new(vec![0, 1], vec![2, 2]);
         ref_tensor.set_tensor_data(TensorData::new_from_data(
             &[2, 2],
             vec![
@@ -209,8 +207,7 @@ mod tests {
                 Complex64::new(0.0, 1.0),
             ],
         ));
-        ref_tn.push_tensor(ref_tensor);
-        ref_tn.set_legs(vec![0, 1]);
+        let ref_tn = CompositeTensor::new(vec![ref_tensor]);
         assert_abs_diff_eq!(&tensor, &ref_tn);
     }
 

--- a/tnc/src/io/qasm/qasm_importer.rs
+++ b/tnc/src/io/qasm/qasm_importer.rs
@@ -51,7 +51,7 @@ mod tests {
         contractionpath::ContractionPath,
         tensornetwork::{
             contraction::contract_tensor_network,
-            tensor::{EdgeIndex, Tensor, TensorIndex},
+            tensor::{CompositeTensor, EdgeIndex, LeafTensor, TensorIndex},
             tensordata::TensorData,
         },
     };
@@ -61,21 +61,25 @@ mod tests {
         edge_id: EdgeIndex,
         t1_id: TensorIndex,
         t2_id: TensorIndex,
-        tn: &Tensor,
+        tn: &CompositeTensor,
     ) -> bool {
-        let overlap = tn.tensor(t1_id) & tn.tensor(t2_id);
+        let t1 = tn.tensor(t1_id).as_leaf().unwrap();
+        let t2 = tn.tensor(t2_id).as_leaf().unwrap();
+        let overlap = t1 & t2;
         overlap.legs().contains(&edge_id)
     }
 
     /// Returns whether the edge is an open edge of the tensor.
-    fn is_open_edge_of(edge_id: EdgeIndex, t1_id: TensorIndex, tn: &Tensor) -> bool {
+    fn is_open_edge_of(edge_id: EdgeIndex, t1_id: TensorIndex, tn: &CompositeTensor) -> bool {
         // Check if the edge is a leg of the tensor
-        if !tn.tensor(t1_id).legs().contains(&edge_id) {
+        let t1 = tn.tensor(t1_id).as_leaf().unwrap();
+        if !t1.legs().contains(&edge_id) {
             return false;
         }
 
         // Check if the edge is not connected to any other tensor
         for (tensor_id, tensor) in tn.tensors().iter().enumerate() {
+            let tensor = tensor.as_leaf().unwrap();
             if tensor_id != t1_id && tensor.legs().contains(&edge_id) {
                 return false;
             }
@@ -85,22 +89,23 @@ mod tests {
 
     struct IdTensor<'a> {
         id: usize,
-        tensor: &'a Tensor,
+        tensor: &'a LeafTensor,
     }
 
     fn get_quantum_tensors(
-        tn: &Tensor,
+        tn: &CompositeTensor,
     ) -> (Vec<IdTensor<'_>>, Vec<IdTensor<'_>>, Vec<IdTensor<'_>>) {
         let mut kets = Vec::new();
         let mut single_qubit_gates = Vec::new();
         let mut two_qubit_gates = Vec::new();
         for (tid, tensor) in tn.tensors().iter().enumerate() {
+            let leaf = tensor.as_leaf().unwrap();
             let id: usize = tid;
-            let legs = tensor.legs().len();
+            let legs = leaf.legs().len();
             match legs {
-                1 => kets.push(IdTensor { id, tensor }),
-                2 => single_qubit_gates.push(IdTensor { id, tensor }),
-                4 => two_qubit_gates.push(IdTensor { id, tensor }),
+                1 => kets.push(IdTensor { id, tensor: leaf }),
+                2 => single_qubit_gates.push(IdTensor { id, tensor: leaf }),
+                4 => two_qubit_gates.push(IdTensor { id, tensor: leaf }),
                 _ => panic!("Tensor with unexpected leg count {legs} in quantum tensor network"),
             }
         }
@@ -160,12 +165,12 @@ mod tests {
 
     /// Contracts the tensor network with an arbitrary contraction order, then
     /// returns the correctly permuted tensor data.
-    fn contract_tn(tn: Tensor, perm: &Permutor) -> TensorData {
+    fn contract_tn(tn: CompositeTensor, perm: &Permutor) -> TensorData {
         let opt_path =
             ContractionPath::simple((1..tn.tensors().len()).map(|tid| (0, tid)).collect());
-        let tn = contract_tensor_network(tn, &opt_path);
-        let mut tn = perm.apply(tn);
-        std::mem::take(&mut tn.tensordata)
+        let leaf = contract_tensor_network(tn, &opt_path);
+        let leaf = perm.apply(leaf);
+        leaf.into_data()
     }
 
     #[test]

--- a/tnc/src/mpi/communication.rs
+++ b/tnc/src/mpi/communication.rs
@@ -7,7 +7,7 @@ use crate::contractionpath::{ContractionPath, SimplePath, SimplePathRef};
 use crate::mpi::mpi_types::{MessageBinaryBlob, RankTensorMapping};
 use crate::mpi::serialization::{deserialize, deserialize_tensor, serialize, serialize_tensor};
 use crate::tensornetwork::contraction::contract_tensor_network;
-use crate::tensornetwork::tensor::Tensor;
+use crate::tensornetwork::tensor::{CompositeTensor, LeafTensor, Tensor};
 
 /// Broadcasts a vector of `data` from `root` to all processes in `world`. For the
 /// receivers, `data` can just be an empty vector.
@@ -123,12 +123,12 @@ pub struct Communication {
 
 /// Distributes the partitioned tensor network to the various processes via MPI.
 pub fn scatter_tensor_network(
-    r_tn: &Tensor,
+    r_tn: &CompositeTensor,
     path: &ContractionPath,
     rank: Rank,
     size: Rank,
     world: &SimpleCommunicator,
-) -> (Tensor, ContractionPath, Communication) {
+) -> (CompositeTensor, ContractionPath, Communication) {
     debug!(rank, size; "Scattering tensor network");
     let root = world.process_at_rank(0);
 
@@ -181,12 +181,12 @@ pub fn scatter_tensor_network(
 
             send_tensor(tensor, target_rank, world);
         }
-        local_tn.unwrap()
+        local_tn.and_then(Tensor::into_composite).unwrap()
     } else if is_tensor_owner {
         debug!("Receiving tensor");
-        receive_tensor(0, world)
+        receive_tensor(0, world).into_composite().unwrap()
     } else {
-        Default::default()
+        CompositeTensor::default()
     };
     debug!("Scattered tensor network");
 
@@ -197,14 +197,13 @@ pub fn scatter_tensor_network(
 /// Uses the `path` as a communication blueprint to iteratively send tensors and contract them in a fan-in.
 /// Assumes that `path` is a valid contraction path.
 pub fn intermediate_reduce_tensor_network(
-    local_tn: &mut Tensor,
+    local_tensor: &mut LeafTensor,
     path: SimplePathRef,
     rank: Rank,
     world: &SimpleCommunicator,
     communication: &Communication,
 ) {
     debug!(rank, path:serde; "Reducing tensor network (intermediate)");
-    assert!(local_tn.is_leaf());
 
     let mut final_rank = 0;
     for (x, y) in path {
@@ -216,18 +215,19 @@ pub fn intermediate_reduce_tensor_network(
             debug!(sender; "Start receiving tensor");
             let received_tensor = receive_tensor(sender, world);
             debug!(sender; "Finish receiving tensor");
+            let received_tensor = received_tensor.into_leaf().unwrap();
 
             // Add local tensor and received tensor into a new tensor network
             let tensor_network =
-                Tensor::new_composite(vec![std::mem::take(local_tn), received_tensor]);
+                CompositeTensor::new(vec![std::mem::take(local_tensor), received_tensor]);
 
             // Contract tensors
             let result = contract_tensor_network(tensor_network, &ContractionPath::single(0, 1));
-            *local_tn = result;
+            *local_tensor = result;
         }
         if sender == rank {
             debug!(receiver; "Start sending tensor");
-            send_tensor(local_tn, receiver, world);
+            send_tensor(local_tensor.as_tensor(), receiver, world);
             debug!(receiver; "Finish sending tensor");
         }
     }
@@ -238,11 +238,11 @@ pub fn intermediate_reduce_tensor_network(
         if rank == 0 {
             debug!(sender = final_rank; "Receiving final tensor");
             let received_tensor = receive_tensor(final_rank, world);
-            *local_tn = received_tensor;
+            *local_tensor = received_tensor.into_leaf().unwrap();
         }
         if rank == final_rank {
             debug!(receiver = 0; "Sending final tensor");
-            send_tensor(local_tn, 0, world);
+            send_tensor(local_tensor.as_tensor(), 0, world);
         }
     }
     debug!("Reduced tensor network");

--- a/tnc/src/mpi/serialization.rs
+++ b/tnc/src/mpi/serialization.rs
@@ -86,15 +86,18 @@ mod tests {
     use num_complex::Complex64;
     use rustc_hash::FxHashMap;
 
-    use crate::tensornetwork::{tensor::Tensor, tensordata::TensorData};
+    use crate::tensornetwork::{
+        tensor::{CompositeTensor, LeafTensor},
+        tensordata::TensorData,
+    };
 
     #[test]
     fn test_serialize_deserialize_tensor_roundtrip() {
         let bond_dims = FxHashMap::from_iter([(1, 2), (2, 2), (3, 2), (4, 2), (5, 2)]);
-        let t2 = Tensor::new_from_map(vec![1, 2, 3], &bond_dims);
-        let t3 = Tensor::new_from_map(vec![2, 3, 4], &bond_dims);
-        let t4 = Tensor::new_from_map(vec![4, 5], &bond_dims);
-        let ta = Tensor::new_composite(vec![t2, t3, t4]);
+        let t2 = LeafTensor::new_from_map(vec![1, 2, 3], &bond_dims);
+        let t3 = LeafTensor::new_from_map(vec![2, 3, 4], &bond_dims);
+        let t4 = LeafTensor::new_from_map(vec![4, 5], &bond_dims);
+        let ta = CompositeTensor::new(vec![t2, t3, t4]).into();
         let serialized = serialize_tensor(&ta);
         let deserialized = deserialize_tensor(&serialized);
         assert_abs_diff_eq!(&ta, &deserialized);
@@ -102,10 +105,9 @@ mod tests {
 
     #[test]
     fn test_serialize_deserialize_tensor_with_data() {
-        let bond_dims = FxHashMap::from_iter([(1, 2), (2, 3)]);
         let data = (0..6).map(|x| Complex64::new(x as f64, 0.0)).collect();
-        let mut tensor = Tensor::new_from_map(vec![1, 2], &bond_dims);
-        tensor.set_tensor_data(TensorData::new_from_data(&[2, 3], data));
+        let data = TensorData::new_from_data(&[2, 3], data);
+        let tensor = LeafTensor::new_with_data(vec![1, 2], vec![2, 3], data).into();
         let serialized = serialize_tensor(&tensor);
         let deserialized = deserialize_tensor(&serialized);
         assert_abs_diff_eq!(&tensor, &deserialized);

--- a/tnc/src/tensornetwork/contraction.rs
+++ b/tnc/src/tensornetwork/contraction.rs
@@ -1,4 +1,5 @@
 //! Functionality to contract tensor networks.
+use itertools::Itertools;
 use log::debug;
 use ndarray::Axis;
 use tblis::{tensor_mult, TensorView};
@@ -6,7 +7,7 @@ use tblis::{tensor_mult, TensorView};
 use crate::{
     contractionpath::ContractionPath,
     tensornetwork::{
-        tensor::Tensor,
+        tensor::{CompositeTensor, LeafTensor, Tensor},
         tensordata::{DataTensor, TensorData},
     },
 };
@@ -31,65 +32,57 @@ use crate::{
 /// let opt_path = result.replace_path();
 /// let result = contract_tensor_network(r_tn, &opt_path);
 /// ```
-pub fn contract_tensor_network(mut tn: Tensor, contract_path: &ContractionPath) -> Tensor {
-    debug!(len = tn.tensors().len(); "Start contracting tensor network");
+pub fn contract_tensor_network(tn: CompositeTensor, contract_path: &ContractionPath) -> LeafTensor {
+    debug!(len = tn.len(); "Start contracting tensor network");
+
+    // Wrap the tensors into options, so we can take out used tensors
+    let mut tensors = tn.into_tensors().into_iter().map(Some).collect_vec();
 
     // Contract child composite tensors first
     for (index, inner_path) in &contract_path.nested {
-        let composite = std::mem::take(&mut tn.tensors[*index]);
-        let contracted = contract_tensor_network(composite, inner_path);
-        tn.tensors[*index] = contracted;
+        let tc = tensors[*index]
+            .take()
+            .and_then(Tensor::into_composite)
+            .unwrap();
+        let contracted = contract_tensor_network(tc, inner_path);
+        tensors[*index] = Some(contracted.into());
     }
 
     // Contract all leaf tensors
     for (i, j) in &contract_path.toplevel {
-        debug!(i, j; "Contracting tensors");
-        tn.contract_tensors(*i, *j);
-        debug!(i, j; "Finished contracting tensors");
+        let ti = tensors[*i].take().and_then(Tensor::into_leaf).unwrap();
+        let tj = tensors[*j].take().and_then(Tensor::into_leaf).unwrap();
+        let contracted = contract_tensors(ti, tj);
+        tensors[*i] = Some(contracted.into());
     }
     debug!("Completed tensor network contraction");
 
-    tn.tensors
-        .retain(|x| !matches!(x.tensor_data(), TensorData::Uncontracted) || x.is_composite());
-    assert!(tn.tensors().len() <= 1, "Not fully contracted");
-    tn.tensors.pop().unwrap_or(tn)
+    // Remove all the None values and return the final tensor
+    tensors
+        .into_iter()
+        .flatten()
+        .exactly_one()
+        .unwrap()
+        .into_leaf()
+        .unwrap()
 }
 
-trait TensorContraction {
-    /// Contracts two tensors.
-    fn contract_tensors(&mut self, tensor_a_loc: usize, tensor_b_loc: usize);
-}
+fn contract_tensors(tensor_a: LeafTensor, tensor_b: LeafTensor) -> LeafTensor {
+    let mut tensor_symmetric_difference = &tensor_a ^ &tensor_b;
 
-impl TensorContraction for Tensor {
-    fn contract_tensors(&mut self, tensor_a_loc: usize, tensor_b_loc: usize) {
-        let tensor_a = std::mem::take(&mut self.tensors[tensor_a_loc]);
-        let tensor_b = std::mem::take(&mut self.tensors[tensor_b_loc]);
+    let (a_legs, _, a_data) = tensor_a.into_inner();
+    let (b_legs, _, b_data) = tensor_b.into_inner();
 
-        let mut tensor_symmetric_difference = &tensor_b ^ &tensor_a;
+    let result = contract_ndarrays(
+        tensor_symmetric_difference.legs(),
+        &a_legs,
+        a_data.into_data(),
+        &b_legs,
+        b_data.into_data(),
+    );
 
-        let Tensor {
-            legs: a_legs,
-            tensordata: a_data,
-            ..
-        } = tensor_a;
-
-        let Tensor {
-            legs: b_legs,
-            tensordata: b_data,
-            ..
-        } = tensor_b;
-
-        let result = contract_ndarrays(
-            &tensor_symmetric_difference.legs,
-            &a_legs,
-            a_data.into_data(),
-            &b_legs,
-            b_data.into_data(),
-        );
-
-        tensor_symmetric_difference.set_tensor_data(TensorData::Matrix(result));
-        self.tensors[tensor_a_loc] = tensor_symmetric_difference;
-    }
+    tensor_symmetric_difference.set_tensor_data(TensorData::Matrix(result));
+    tensor_symmetric_difference
 }
 
 fn contract_ndarrays(
@@ -131,10 +124,7 @@ mod tests {
     use rustc_hash::FxHashMap;
     use serde::Deserialize;
 
-    use crate::{
-        path,
-        tensornetwork::{contraction::TensorContraction, tensor::Tensor, tensordata::TensorData},
-    };
+    use crate::{path, tensornetwork::tensordata::TensorData};
 
     #[derive(Debug, Deserialize)]
     struct TestTensor {
@@ -151,81 +141,61 @@ mod tests {
         serde_json::from_str(TEST_DATA).unwrap()
     }
 
+    fn pop_test_tensor(name: &str, data: &mut TestData) -> LeafTensor {
+        let test_tensor = data.remove(name).unwrap();
+        let mut tensor = LeafTensor::new(test_tensor.legs, test_tensor.shape);
+        tensor.set_tensor_data(TensorData::new_from_data(
+            &tensor.shape().unwrap(),
+            test_tensor.data,
+        ));
+        tensor
+    }
+
     #[test]
     fn test_tensor_contraction() {
         let mut data = load_test_data();
-        let ta = data.remove("A").unwrap();
-        let tb = data.remove("B").unwrap();
-        let tc = data.remove("C").unwrap();
-        let tab = data.remove("AxB").unwrap();
-        let tbc = data.remove("BxC").unwrap();
-
         // t1 is of shape [3, 2, 7]
-        let mut t1 = Tensor::new(ta.legs, ta.shape);
+        let t1 = pop_test_tensor("A", &mut data);
         // t2 is of shape [7, 8, 6]
-        let mut t2 = Tensor::new(tb.legs, tb.shape);
+        let t2 = pop_test_tensor("B", &mut data);
         // t3 is of shape [3, 5, 8]
-        let mut t3 = Tensor::new(tc.legs, tc.shape);
+        let t3 = pop_test_tensor("C", &mut data);
         // t12 is of shape [8, 6, 3, 2]
-        let mut t12 = Tensor::new(tab.legs, tab.shape);
+        let t12 = pop_test_tensor("AxB", &mut data);
         // t23 is of shape [3, 5, 7, 6]
-        let mut t23 = Tensor::new(tbc.legs, tbc.shape);
+        let t23 = pop_test_tensor("BxC", &mut data);
 
-        t1.set_tensor_data(TensorData::new_from_data(&t1.shape().unwrap(), ta.data));
+        let out = contract_tensors(t2.clone(), t1);
+        assert_abs_diff_eq!(&out, &t12, epsilon = 1e-14);
 
-        t2.set_tensor_data(TensorData::new_from_data(&t2.shape().unwrap(), tb.data));
-        t3.set_tensor_data(TensorData::new_from_data(&t3.shape().unwrap(), tc.data));
-
-        t12.set_tensor_data(TensorData::new_from_data(&t12.shape().unwrap(), tab.data));
-
-        t23.set_tensor_data(TensorData::new_from_data(&t23.shape().unwrap(), tbc.data));
-
-        let mut tn_12 = Tensor::new_composite(vec![t1.clone(), t2.clone(), t3.clone()]);
-
-        tn_12.contract_tensors(0, 1);
-        assert_abs_diff_eq!(tn_12.tensor(0), &t12, epsilon = 1e-14);
-
-        let mut tn_23 = Tensor::new_composite(vec![t1, t2, t3]);
-
-        tn_23.contract_tensors(1, 2);
-        assert_abs_diff_eq!(tn_23.tensor(1), &t23, epsilon = 1e-14);
+        let out = contract_tensors(t3, t2);
+        assert_abs_diff_eq!(&out, &t23, epsilon = 1e-14);
     }
 
     #[test]
     fn test_tn_contraction() {
         let mut data = load_test_data();
-        let ta = data.remove("A").unwrap();
-        let tb = data.remove("B").unwrap();
-        let tc = data.remove("C").unwrap();
-        let tabc = data.remove("ABxC").unwrap();
-
         // t1 is of shape [3, 2, 7]
-        let mut t1 = Tensor::new(ta.legs, ta.shape);
+        let t1 = pop_test_tensor("A", &mut data);
         // t2 is of shape [7, 8, 6]
-        let mut t2 = Tensor::new(tb.legs, tb.shape);
+        let t2 = pop_test_tensor("B", &mut data);
         // t3 is of shape [3, 5, 8]
-        let mut t3 = Tensor::new(tc.legs, tc.shape);
+        let t3 = pop_test_tensor("C", &mut data);
         // tout is of shape [5, 6, 2]
-        let mut tout = Tensor::new(tabc.legs, tabc.shape);
+        let tout = pop_test_tensor("ABxC", &mut data);
 
-        t1.set_tensor_data(TensorData::new_from_data(&t1.shape().unwrap(), ta.data));
-
-        t2.set_tensor_data(TensorData::new_from_data(&t2.shape().unwrap(), tb.data));
-        t3.set_tensor_data(TensorData::new_from_data(&t3.shape().unwrap(), tc.data));
-        tout.set_tensor_data(TensorData::new_from_data(&tout.shape().unwrap(), tabc.data));
-
-        let tn = Tensor::new_composite(vec![t1, t2, t3]);
-        let contract_path = path![(0, 1), (0, 2)];
+        let tn = CompositeTensor::new(vec![t1, t2, t3]);
+        let contract_path = path![(1, 0), (2, 1)];
 
         let result = contract_tensor_network(tn, &contract_path);
-        assert_abs_diff_eq!(result, &tout, epsilon = 1e-14);
+        assert_abs_diff_eq!(&result, &tout, epsilon = 1e-14);
     }
 
     #[test]
     fn test_outer_product_contraction() {
         let bond_dims = FxHashMap::from_iter([(0, 3), (1, 2)]);
-        let mut t1 = Tensor::new_from_map(vec![0], &bond_dims);
-        let mut t2 = Tensor::new_from_map(vec![1], &bond_dims);
+        let mut t1 = LeafTensor::new_from_map(vec![0], &bond_dims);
+        let mut t2 = LeafTensor::new_from_map(vec![1], &bond_dims);
         t1.set_tensor_data(TensorData::new_from_data(
             &[3],
             vec![
@@ -238,35 +208,35 @@ mod tests {
             &[2],
             vec![Complex64::new(-4.0, 2.0), Complex64::new(0.0, -1.0)],
         ));
-        let t3 = Tensor::new_composite(vec![t1, t2]);
+        let t3 = CompositeTensor::new(vec![t1, t2]);
         let contract_path = path![(0, 1)];
 
-        let mut tn_ref = Tensor::new_from_map(vec![1, 0], &bond_dims);
+        let mut tn_ref = LeafTensor::new_from_map(vec![0, 1], &bond_dims);
         tn_ref.set_tensor_data(TensorData::new_from_data(
-            &[2, 3],
+            &[3, 2],
             vec![
                 Complex64::new(-4.0, 2.0),
-                Complex64::new(-18.0, -16.0),
-                Complex64::new(-10.0, 10.0),
                 Complex64::new(0.0, -1.0),
+                Complex64::new(-18.0, -16.0),
                 Complex64::new(5.0, -2.0),
+                Complex64::new(-10.0, 10.0),
                 Complex64::new(-1.0, -3.0),
             ],
         ));
 
         let result = contract_tensor_network(t3, &contract_path);
-        assert_abs_diff_eq!(result, &tn_ref);
+        assert_abs_diff_eq!(&result, &tn_ref);
     }
 
     #[test]
     fn dimension_order() {
-        let mut ket0 = Tensor::new_from_const(vec![0], 2);
+        let mut ket0 = LeafTensor::new_from_const(vec![0], 2);
         ket0.set_tensor_data(TensorData::new_from_data(
             &[2],
             vec![Complex64::ONE, Complex64::ZERO],
         ));
 
-        let mut mat = Tensor::new_from_const(vec![1, 0], 2);
+        let mut mat = LeafTensor::new_from_const(vec![1, 0], 2);
         mat.set_tensor_data(TensorData::new_from_data(
             &[2, 2],
             vec![
@@ -277,10 +247,10 @@ mod tests {
             ],
         ));
 
-        let tn = Tensor::new_composite(vec![ket0, mat]);
+        let tn = CompositeTensor::new(vec![ket0, mat]);
         let contract_path = path![(0, 1)];
 
-        let mut tn_ref = Tensor::new_from_const(vec![1], 2);
+        let mut tn_ref = LeafTensor::new_from_const(vec![1], 2);
         tn_ref.set_tensor_data(TensorData::new_from_data(
             &[2],
             vec![Complex64::new(1.0, 0.0), Complex64::new(3.0, 0.0)],

--- a/tnc/src/tensornetwork/partitioning.rs
+++ b/tnc/src/tensornetwork/partitioning.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use kahypar::{partition, KaHyParContext};
 use rustc_hash::FxHashMap;
 
-use crate::tensornetwork::tensor::Tensor;
+use crate::tensornetwork::tensor::{CompositeTensor, LeafTensor};
 
 mod partition_config;
 pub use partition_config::PartitioningStrategy;
@@ -24,23 +24,21 @@ const LOG_SCALE_FACTOR: f64 = 1e5;
 /// The usize associated with each Tensor indicates its partionining.
 ///
 /// # Arguments
-///
 /// * `tensor_network` - [`Tensor`] to be partitionined
 /// * `k` - imbalance parameter for `KaHyPar`
 /// * `partition_strategy` - The strategy to pass to `KaHyPar`
 /// * `min` - if `true` performs `min_cut` to partition tensor network, if `false`, uses `max_cut`
-///
 pub fn find_partitioning(
-    tensor_network: &Tensor,
+    tensor_network: &CompositeTensor,
     k: i32,
     partitioning_strategy: PartitioningStrategy,
     min: bool,
 ) -> Vec<usize> {
     if k == 1 {
-        return vec![0; tensor_network.tensors().len()];
+        return vec![0; tensor_network.len()];
     }
 
-    let num_vertices = tensor_network.tensors().len() as u32;
+    let num_vertices = tensor_network.len() as u32;
     let mut context = KaHyParContext::new();
     partitioning_strategy.apply(&mut context);
 
@@ -54,6 +52,9 @@ pub fn find_partitioning(
 
     let mut edge_dict = FxHashMap::default();
     for (tensor_id, tensor) in tensor_network.tensors().iter().enumerate() {
+        let tensor = tensor
+            .as_leaf()
+            .expect("Partitioning currently only supports one level of nesting");
         for (leg, dim) in tensor.edges() {
             edge_dict
                 .entry(leg)
@@ -63,7 +64,7 @@ pub fn find_partitioning(
                     hyperedge_indices.push(hyperedge_indices.last().unwrap() + 2);
                     // Use log weights, because KaHyPar minimizes the sum of weights while we need the product.
                     // Since it accepts only integer weights, we scale the log values before rounding.
-                    let weight = LOG_SCALE_FACTOR * (*dim as f64).log2();
+                    let weight = LOG_SCALE_FACTOR * (dim as f64).log2();
                     hyperedge_weights.push(x * weight as i32);
                     *entry = tensor_id;
                 })
@@ -92,14 +93,12 @@ pub fn find_partitioning(
 /// Returns a `Vec<usize>` of length equal to the number of input tensors minus one, acts as a communication scheme.
 ///
 /// # Arguments
-///
-/// * `tensors` - &[(usize, `Tensor`)] to be partitioned. each tuple contains the intermediate contraction cost and intermediate tensor for communication.
+/// * `tensors` - &[(usize, `Tensor`)] to be partitioned. Each tuple contains the intermediate contraction cost and intermediate tensor for communication.
 /// * `k` - number of partitions
 /// * `partitioning_strategy` - The strategy to pass to `KaHyPar`
 /// * `min` - if `true` performs `min_cut` to partition tensor network, if `false`, uses `max_cut`
-///
 pub fn communication_partitioning(
-    tensors: &[(usize, Tensor)],
+    tensors: &[(usize, LeafTensor)],
     k: i32,
     imbalance: f64,
     partitioning_strategy: PartitioningStrategy,
@@ -133,7 +132,7 @@ pub fn communication_partitioning(
                     hyperedge_indices.push(hyperedge_indices.last().unwrap() + 2);
                     // Use log weights, because KaHyPar minimizes the sum of weights while we need the product.
                     // Since it accepts only integer weights, we scale the log values before rounding.
-                    let weight = LOG_SCALE_FACTOR * (*dim as f64).log2();
+                    let weight = LOG_SCALE_FACTOR * (dim as f64).log2();
                     hyperedge_weights.push(x * weight as i32);
                     *entry = tensor_id;
                 })
@@ -162,16 +161,16 @@ pub fn communication_partitioning(
 
 /// Partitions the tensor network based on the `partitioning` vector that assigns
 /// each vector to a partition.
-pub fn partition_tensor_network(tn: Tensor, partitioning: &[usize]) -> Tensor {
+pub fn partition_tensor_network(tn: CompositeTensor, partitioning: &[usize]) -> CompositeTensor {
     let partition_ids = partitioning.iter().unique().copied().collect_vec();
     let partition_dict =
         zip(partition_ids.iter().copied(), 0..partition_ids.len()).collect::<FxHashMap<_, _>>();
 
-    let mut partitions = vec![Tensor::default(); partition_ids.len()];
-    for (partition_id, tensor) in zip(partitioning, tn.tensors) {
-        partitions[partition_dict[partition_id]].push_tensor(tensor);
+    let mut partitions = vec![CompositeTensor::default(); partition_ids.len()];
+    for (partition_id, tensor) in zip(partitioning, tn.tensors()) {
+        partitions[partition_dict[partition_id]].push_tensor(tensor.clone());
     }
-    Tensor::new_composite(partitions)
+    CompositeTensor::new(partitions)
 }
 
 #[cfg(test)]
@@ -182,9 +181,9 @@ mod tests {
     use rustc_hash::FxHashMap;
 
     use crate::tensornetwork::partitioning::partition_config::PartitioningStrategy;
-    use crate::tensornetwork::tensor::{EdgeIndex, Tensor};
+    use crate::tensornetwork::tensor::{EdgeIndex, LeafTensor};
 
-    fn setup_complex() -> (Tensor, FxHashMap<EdgeIndex, u64>) {
+    fn setup_complex() -> (CompositeTensor, FxHashMap<EdgeIndex, u64>) {
         let bond_dims = FxHashMap::from_iter([
             (0, 27),
             (1, 18),
@@ -200,13 +199,13 @@ mod tests {
             (11, 17),
         ]);
         (
-            Tensor::new_composite(vec![
-                Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-                Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
-                Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-                Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
-                Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+            CompositeTensor::new(vec![
+                LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+                LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
+                LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+                LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
+                LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
             ]),
             bond_dims,
         )
@@ -215,26 +214,26 @@ mod tests {
     #[test]
     fn test_simple_partitioning() {
         let (tn, bond_dims) = setup_complex();
-        let ref_tensor_1 = Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![6, 8, 9], &bond_dims),
-            Tensor::new_from_map(vec![10, 8, 9], &bond_dims),
+        let ref_tensor_1 = CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims),
+            LeafTensor::new_from_map(vec![10, 8, 9], &bond_dims),
         ]);
-        let ref_tensor_2 = Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![5, 1, 0], &bond_dims),
+        let ref_tensor_2 = CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![0, 1, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![5, 1, 0], &bond_dims),
         ]);
-        let ref_tensor_3 = Tensor::new_composite(vec![
-            Tensor::new_from_map(vec![4, 3, 2], &bond_dims),
-            Tensor::new_from_map(vec![4, 5, 6], &bond_dims),
+        let ref_tensor_3 = CompositeTensor::new(vec![
+            LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims),
+            LeafTensor::new_from_map(vec![4, 5, 6], &bond_dims),
         ]);
         let partitioning = find_partitioning(&tn, 3, PartitioningStrategy::MinCut, true);
         assert_eq!(partitioning, [2, 1, 2, 0, 0, 1]);
         let partitioned_tn = partition_tensor_network(tn, partitioning.as_slice());
         assert_eq!(partitioned_tn.tensors().len(), 3);
 
-        assert_abs_diff_eq!(partitioned_tn.tensor(2), &ref_tensor_1);
-        assert_abs_diff_eq!(partitioned_tn.tensor(1), &ref_tensor_2);
-        assert_abs_diff_eq!(partitioned_tn.tensor(0), &ref_tensor_3);
+        assert_abs_diff_eq!(partitioned_tn.tensor(2), ref_tensor_1.as_tensor());
+        assert_abs_diff_eq!(partitioned_tn.tensor(1), ref_tensor_2.as_tensor());
+        assert_abs_diff_eq!(partitioned_tn.tensor(0), ref_tensor_3.as_tensor());
     }
 
     #[test]

--- a/tnc/src/tensornetwork/tensor.rs
+++ b/tnc/src/tensornetwork/tensor.rs
@@ -3,6 +3,7 @@ use std::num::TryFromIntError;
 use std::ops::{BitAnd, BitOr, BitXor, BitXorAssign, Sub};
 
 use approx::AbsDiffEq;
+use bytemuck::{TransparentWrapper, TransparentWrapperAlloc};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
@@ -15,49 +16,459 @@ pub type EdgeIndex = usize;
 /// Index of a tensor in a tensor network.
 pub type TensorIndex = usize;
 
-/// Abstract representation of a tensor. Can be a *composite* tensor (that is, a
-/// tensor network) or a *leaf* tensor.
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct Tensor {
+/// An abstract tensor. This can either be a [`CompositeTensor`] or a [`LeafTensor`].
+#[derive(Debug, Clone, PartialEq, TransparentWrapper, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct Tensor(TensorRepr);
+
+/// A composite tensor that has other tensors as children, similar to a tensor
+/// network.
+#[derive(Debug, Clone, PartialEq, TransparentWrapper, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct CompositeTensor(TensorRepr);
+
+/// A single leaf tensor.
+#[derive(Debug, Clone, PartialEq, TransparentWrapper, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct LeafTensor(TensorRepr);
+
+/// The type of a tensor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TensorType {
+    Composite,
+    Leaf,
+}
+
+/// Abstract representation of a tensor.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TensorRepr {
+    /// The type of this tensor.
+    kind: TensorType,
+
     /// The inner tensors that make up this tensor. If non-empty, this tensor is
     /// called a *composite* tensor.
-    pub(crate) tensors: Vec<Tensor>,
+    tensors: Vec<Tensor>,
 
     /// The legs of the tensor. Each leg should have a unique id. Connected tensors
     /// are recognized by having at least one leg id in common.
-    pub(crate) legs: Vec<EdgeIndex>,
+    legs: Vec<EdgeIndex>,
 
     /// The bond dimensions of the legs, same length and order as `legs`. It is
     /// assumed (but not checked!) that the bond dimensions of different tensors that
     /// connect to the same leg match.
-    pub(crate) bond_dims: Vec<u64>,
+    bond_dims: Vec<u64>,
 
     /// The data of the tensor.
-    pub(crate) tensordata: TensorData,
+    tensordata: TensorData,
 }
 
 impl Tensor {
-    /// Constructs a Tensor object with the given `legs` (edge ids) and corresponding
-    /// `bond_dims`. The tensor doesn't have underlying data.
+    /// Returns the kind of this tensor.
     #[inline]
-    pub(crate) fn new(legs: Vec<EdgeIndex>, bond_dims: Vec<u64>) -> Self {
-        assert_eq!(legs.len(), bond_dims.len());
-        Self {
-            legs,
-            bond_dims,
-            ..Default::default()
-        }
+    pub fn kind(&self) -> TensorType {
+        self.0.kind
     }
 
-    /// Constructs a Tensor using with the given edge ids and a mapping of edge ids
-    /// to corresponding bond dimension.
+    /// Returns true if the tensor is a leaf tensor, without any nested tensors.
     ///
     /// # Examples
     /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
+    /// # use tnc::tensornetwork::tensor::{CompositeTensor, LeafTensor, Tensor};
     /// # use rustc_hash::FxHashMap;
     /// let bond_dims = FxHashMap::from_iter([(1, 2), (2, 4), (3, 6)]);
-    /// let tensor = Tensor::new_from_map(vec![1, 2, 3], &bond_dims);
+    /// let leaf: Tensor = LeafTensor::new_from_map(vec![1, 2, 3], &bond_dims).into();
+    /// assert_eq!(leaf.is_leaf(), true);
+    /// let comp: Tensor = CompositeTensor::new(vec![leaf]).into();
+    /// assert_eq!(comp.is_leaf(), false);
+    /// ```
+    #[inline]
+    pub fn is_leaf(&self) -> bool {
+        self.kind() == TensorType::Leaf
+    }
+
+    /// Returns a reference to this tensor as a [`LeafTensor`] if it is one.
+    #[inline]
+    pub fn as_leaf(&self) -> Option<&LeafTensor> {
+        self.is_leaf()
+            .then(|| LeafTensor::wrap_ref(Self::peel_ref(self)))
+    }
+
+    /// Returns this tensor as a [`LeafTensor`] if it is one.
+    #[inline]
+    pub fn into_leaf(self) -> Option<LeafTensor> {
+        self.is_leaf().then(|| LeafTensor::wrap(Self::peel(self)))
+    }
+
+    /// Returns true if the tensor is composite.
+    ///
+    /// # Examples
+    /// ```
+    /// # use tnc::tensornetwork::tensor::{CompositeTensor, LeafTensor, Tensor};
+    /// # use rustc_hash::FxHashMap;
+    /// let bond_dims = FxHashMap::from_iter([(1, 2), (2, 4), (3, 6)]);
+    /// let leaf: Tensor = LeafTensor::new_from_map(vec![1, 2, 3], &bond_dims).into();
+    /// assert_eq!(leaf.is_composite(), false);
+    /// let comp: Tensor = CompositeTensor::new(vec![leaf]).into();
+    /// assert_eq!(comp.is_composite(), true);
+    /// ```
+    #[inline]
+    pub fn is_composite(&self) -> bool {
+        self.kind() == TensorType::Composite
+    }
+
+    /// Returns a reference to this tensor as a [`CompositeTensor`] if it is one.
+    #[inline]
+    pub fn as_composite(&self) -> Option<&CompositeTensor> {
+        self.is_composite()
+            .then(|| CompositeTensor::wrap_ref(Self::peel_ref(self)))
+    }
+
+    /// Returns this tensor as a [`CompositeTensor`] if it is one.
+    #[inline]
+    pub fn into_composite(self) -> Option<CompositeTensor> {
+        self.is_composite()
+            .then(|| CompositeTensor::wrap(Self::peel(self)))
+    }
+}
+
+pub trait TensorList {
+    fn into_tensors(self) -> Vec<Tensor>;
+    fn as_tensors(&self) -> &[Tensor];
+}
+
+impl TensorList for Vec<Tensor> {
+    #[inline]
+    fn into_tensors(self) -> Vec<Tensor> {
+        self
+    }
+
+    #[inline]
+    fn as_tensors(&self) -> &[Tensor] {
+        self
+    }
+}
+
+impl From<LeafTensor> for Tensor {
+    #[inline]
+    fn from(value: LeafTensor) -> Self {
+        Self::wrap(LeafTensor::peel(value))
+    }
+}
+
+impl TensorList for Vec<LeafTensor> {
+    #[inline]
+    fn into_tensors(self) -> Vec<Tensor> {
+        Tensor::wrap_vec(LeafTensor::peel_vec(self))
+    }
+
+    #[inline]
+    fn as_tensors(&self) -> &[Tensor] {
+        Tensor::wrap_slice(LeafTensor::peel_slice(self))
+    }
+}
+
+impl From<CompositeTensor> for Tensor {
+    #[inline]
+    fn from(value: CompositeTensor) -> Self {
+        Self::wrap(CompositeTensor::peel(value))
+    }
+}
+
+impl TensorList for Vec<CompositeTensor> {
+    #[inline]
+    fn into_tensors(self) -> Vec<Tensor> {
+        Tensor::wrap_vec(CompositeTensor::peel_vec(self))
+    }
+
+    #[inline]
+    fn as_tensors(&self) -> &[Tensor] {
+        Tensor::wrap_slice(CompositeTensor::peel_slice(self))
+    }
+}
+
+impl CompositeTensor {
+    /// Creates a new composite tensor with the given nested tensors.
+    #[inline]
+    pub fn new<T>(tensors: T) -> Self
+    where
+        T: TensorList,
+    {
+        Self(TensorRepr {
+            kind: TensorType::Composite,
+            tensors: tensors.into_tensors(),
+            legs: Vec::new(),
+            bond_dims: Vec::new(),
+            tensordata: TensorData::None,
+        })
+    }
+
+    /// Returns a reference to this composite tensor as a [`Tensor`].
+    #[inline]
+    pub fn as_tensor(&self) -> &Tensor {
+        Tensor::wrap_ref(Self::peel_ref(self))
+    }
+
+    /// Returns the children tensors.
+    ///
+    /// # Examples
+    /// ```
+    /// # use tnc::tensornetwork::tensor::{CompositeTensor, LeafTensor, Tensor};
+    /// # use rustc_hash::FxHashMap;
+    /// # use approx::assert_abs_diff_eq;
+    /// let bond_dims = FxHashMap::from_iter([(0, 17), (1, 19), (2, 8)]);
+    /// let v1 = LeafTensor::new_from_map(vec![0, 1], &bond_dims);
+    /// let v2 = LeafTensor::new_from_map(vec![1, 2], &bond_dims);
+    /// let tn = CompositeTensor::new(vec![v1.clone(), v2.clone()]);
+    /// for (tensor, ref_tensor) in std::iter::zip(tn.tensors(), vec![v1, v2]){
+    ///    assert_abs_diff_eq!(tensor, ref_tensor.as_tensor());
+    /// }
+    /// ```
+    #[inline]
+    pub fn tensors(&self) -> &Vec<Tensor> {
+        &self.0.tensors
+    }
+
+    /// Get the ith tensor.
+    ///
+    /// # Examples
+    /// ```
+    /// # use tnc::tensornetwork::tensor::{CompositeTensor, LeafTensor, Tensor};
+    /// # use rustc_hash::FxHashMap;
+    /// # use approx::assert_abs_diff_eq;
+    /// let bond_dims = FxHashMap::from_iter([(0, 17), (1, 19), (2, 8)]);
+    /// let v1 = LeafTensor::new_from_map(vec![0, 1], &bond_dims);
+    /// let v2 = LeafTensor::new_from_map(vec![1, 2], &bond_dims);
+    /// let tn = CompositeTensor::new(vec![v1.clone(), v2]);
+    /// assert_abs_diff_eq!(tn.tensor(0), v1.as_tensor());
+    /// ```
+    #[inline]
+    pub fn tensor(&self, i: TensorIndex) -> &Tensor {
+        &self.0.tensors[i]
+    }
+
+    /// Converts this tensor into the vec of its children.
+    #[inline]
+    pub fn into_tensors(self) -> Vec<Tensor> {
+        self.0.tensors
+    }
+
+    /// Returns true if the tensor is empty. This means, it doesn't have any
+    /// children.
+    ///
+    /// # Examples
+    /// ```
+    /// # use tnc::tensornetwork::tensor::CompositeTensor;
+    /// let tensor = CompositeTensor::default();
+    /// assert_eq!(tensor.is_empty(), true);
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.tensors.is_empty()
+    }
+
+    /// Returns the number of direct children of this tensor.
+    ///
+    /// # Examples
+    /// ```
+    /// # use tnc::tensornetwork::tensor::CompositeTensor;
+    /// let tensor = CompositeTensor::default();
+    /// assert_eq!(tensor.len(), 0);
+    /// ```
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.tensors.len()
+    }
+
+    /// Gets a nested [`Tensor`] based on the `nested_indices` which specify the
+    /// index of the tensor at each level of the hierarchy.
+    ///
+    /// # Examples
+    /// ```
+    /// # use tnc::tensornetwork::tensor::{CompositeTensor, LeafTensor};
+    /// # use rustc_hash::FxHashMap;
+    /// let bond_dims = FxHashMap::from_iter([(0, 17), (1, 19), (2, 8), (3, 2), (4, 1)]);
+    /// let mut v1 = LeafTensor::new_from_map(vec![0, 1], &bond_dims);
+    /// let mut v2 = LeafTensor::new_from_map(vec![1, 2], &bond_dims);
+    /// let mut v3 = LeafTensor::new_from_map(vec![2, 3], &bond_dims);
+    /// let mut v4 = LeafTensor::new_from_map(vec![3, 4], &bond_dims);
+    /// let tn1 = CompositeTensor::new(vec![v1, v2]);
+    /// let tn2 = CompositeTensor::new(vec![v3.clone(), v4]);
+    /// let nested_tn = CompositeTensor::new(vec![tn1, tn2]);
+    ///
+    /// let found = nested_tn.nested_tensor(&[1, 0]);
+    /// assert!(found.is_leaf());
+    /// let found = found.as_leaf().unwrap();
+    /// assert_eq!(found.legs(), v3.legs());
+    /// ```
+    pub fn nested_tensor(&self, nested_indices: &[usize]) -> &Tensor {
+        let mut tensor = self.as_tensor();
+        for index in nested_indices {
+            tensor = tensor.as_composite().unwrap().tensor(*index);
+        }
+        tensor
+    }
+
+    /// Returns the total number of leaf tensors in the hierarchy.
+    pub fn total_num_tensors(&self) -> usize {
+        self.0
+            .tensors
+            .iter()
+            .map(|t| match t.kind() {
+                TensorType::Composite => t.as_composite().unwrap().total_num_tensors(),
+                TensorType::Leaf => 1,
+            })
+            .sum()
+    }
+
+    /// Pushes additional `tensor` into this composite tensor.
+    #[inline]
+    pub fn push_tensor<T>(&mut self, tensor: T)
+    where
+        T: Into<Tensor>,
+    {
+        self.0.tensors.push(tensor.into());
+    }
+
+    /// Pushes additional `tensors` into this composite tensor.
+    #[inline]
+    pub fn push_tensors<T>(&mut self, tensors: T)
+    where
+        T: TensorList,
+    {
+        let mut tensors = tensors.into_tensors();
+        self.0.tensors.append(&mut tensors);
+    }
+
+    /// Reserves space for at least `additional` more tensors to be pushed to this
+    /// composite tensor without reallocation.
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.tensors.reserve(additional);
+    }
+
+    /// Returns whether all tensors inside this tensor are connected. This currently
+    /// requires all children to be leaf tensors.
+    ///
+    /// # Examples
+    /// ```
+    /// # use tnc::tensornetwork::tensor::{CompositeTensor, LeafTensor};
+    /// # use rustc_hash::FxHashMap;
+    /// // Create a tensor network with two connected tensors
+    /// let bond_dims = FxHashMap::from_iter([(0, 17), (1, 19), (2, 8), (3, 5)]);
+    /// let v1 = LeafTensor::new_from_map(vec![0, 1], &bond_dims);
+    /// let v2 = LeafTensor::new_from_map(vec![1, 2], &bond_dims);
+    /// let mut tn = CompositeTensor::new(vec![v1, v2]);
+    /// assert!(tn.is_connected());
+    ///
+    /// // Introduce a new tensor that is not connected
+    /// let v3 = LeafTensor::new_from_map(vec![3], &bond_dims);
+    /// tn.push_tensor(v3);
+    /// assert!(!tn.is_connected());
+    /// ```
+    pub fn is_connected(&self) -> bool {
+        let num_tensors = self.len();
+        let mut uf = UnionFind::new(num_tensors);
+
+        for t1_id in 0..num_tensors {
+            for t2_id in (t1_id + 1)..num_tensors {
+                let t1 = self
+                    .tensor(t1_id)
+                    .as_leaf()
+                    .expect("Expected all children to be leaves");
+                let t2 = self
+                    .tensor(t2_id)
+                    .as_leaf()
+                    .expect("Expected all children to be leaves");
+                if !(t1 & t2).legs().is_empty() {
+                    uf.union(t1_id, t2_id);
+                }
+            }
+        }
+
+        uf.count_sets() == 1
+    }
+
+    /// Get output legs after tensor contraction.
+    pub fn external_tensor(&self) -> LeafTensor {
+        self.tensors()
+            .iter()
+            .fold(LeafTensor::default(), |acc, tensor| {
+                let tensor = match tensor.kind() {
+                    TensorType::Composite => &tensor.as_composite().unwrap().external_tensor(),
+                    TensorType::Leaf => tensor.as_leaf().unwrap(),
+                };
+                &acc ^ tensor
+            })
+    }
+}
+
+impl Default for CompositeTensor {
+    fn default() -> Self {
+        Self(TensorRepr {
+            kind: TensorType::Composite,
+            tensors: Vec::new(),
+            legs: Vec::new(),
+            bond_dims: Vec::new(),
+            tensordata: TensorData::None,
+        })
+    }
+}
+
+impl AbsDiffEq for CompositeTensor {
+    type Epsilon = f64;
+
+    fn default_epsilon() -> Self::Epsilon {
+        f64::EPSILON
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+        for (tensor, other_tensor) in zip(self.tensors(), other.tensors()) {
+            if !Tensor::abs_diff_eq(tensor, other_tensor, epsilon) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl LeafTensor {
+    /// Constructs a leaf tensor object with the given `legs` (edge ids) and
+    /// corresponding `bond_dims`. The tensor doesn't have underlying data.
+    #[inline]
+    pub(crate) fn new(legs: Vec<EdgeIndex>, bond_dims: Vec<u64>) -> Self {
+        Self::new_with_data(legs, bond_dims, TensorData::None)
+    }
+
+    /// Constructs a leaf tensor object with the given `legs` (edge ids),
+    /// corresponding `bond_dims` and `data`.
+    #[inline]
+    pub(crate) fn new_with_data(
+        legs: Vec<EdgeIndex>,
+        bond_dims: Vec<u64>,
+        data: TensorData,
+    ) -> Self {
+        assert_eq!(legs.len(), bond_dims.len());
+        Self(TensorRepr {
+            kind: TensorType::Leaf,
+            legs,
+            tensors: Vec::new(),
+            bond_dims,
+            tensordata: data,
+        })
+    }
+
+    /// Constructs a leaf tensor with the given edge ids and a mapping of edge ids
+    /// to corresponding bond dimensions.
+    ///
+    /// # Examples
+    /// ```
+    /// # use tnc::tensornetwork::tensor::LeafTensor;
+    /// # use rustc_hash::FxHashMap;
+    /// let bond_dims = FxHashMap::from_iter([(1, 2), (2, 4), (3, 6)]);
+    /// let tensor = LeafTensor::new_from_map(vec![1, 2, 3], &bond_dims);
     /// assert_eq!(tensor.legs(), &[1, 2, 3]);
     /// assert_eq!(tensor.bond_dims(), &[2, 4, 6]);
     /// ```
@@ -67,13 +478,13 @@ impl Tensor {
         Self::new(legs, bond_dims)
     }
 
-    /// Constructs a Tensor with the given edge ids and the same bond dimension for
-    /// all edges.
+    /// Constructs a leaf tensor with the given edge ids and the same bond dimension
+    /// for all edges.
     ///
     /// # Examples
     /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
-    /// let tensor = Tensor::new_from_const(vec![1, 2, 3], 2);
+    /// # use tnc::tensornetwork::tensor::LeafTensor;
+    /// let tensor = LeafTensor::new_from_const(vec![1, 2, 3], 2);
     /// assert_eq!(tensor.legs(), &[1, 2, 3]);
     /// assert_eq!(tensor.bond_dims(), &[2, 2, 2]);
     /// ```
@@ -83,139 +494,66 @@ impl Tensor {
         Self::new(legs, bond_dims)
     }
 
-    /// Creates a new composite tensor with the given nested tensors.
+    /// Returns a reference to this leaf tensor as a [`Tensor`].
     #[inline]
-    pub fn new_composite(tensors: Vec<Self>) -> Self {
-        Self {
-            tensors,
-            ..Default::default()
-        }
+    pub fn as_tensor(&self) -> &Tensor {
+        Tensor::wrap_ref(Self::peel_ref(self))
     }
 
-    /// Returns edge ids of Tensor object.
+    /// Returns a new leaf tensor with the same legs and bond dimensions as this
+    /// tensor, but without any data.
+    #[inline]
+    pub fn shallow_clone(&self) -> Self {
+        Self::new(self.legs().clone(), self.bond_dims().clone())
+    }
+
+    /// Returns edge ids of the tensor.
     ///
     /// # Examples
     /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
-    /// let tensor = Tensor::new_from_const(vec![1, 2, 3], 3);
+    /// # use tnc::tensornetwork::tensor::LeafTensor;
+    /// let tensor = LeafTensor::new_from_const(vec![1, 2, 3], 3);
     /// assert_eq!(tensor.legs(), &[1, 2, 3]);
     /// ```
     #[inline]
     pub fn legs(&self) -> &Vec<EdgeIndex> {
-        &self.legs
-    }
-
-    /// Internal method to set legs. Needs pub(crate) for contraction order finding for hierarchies.
-    #[inline]
-    pub(crate) fn set_legs(&mut self, legs: Vec<EdgeIndex>) {
-        self.legs = legs;
+        &self.0.legs
     }
 
     /// Returns an iterator of tuples of leg ids and their corresponding bond size.
     #[inline]
-    pub fn edges(&self) -> impl Iterator<Item = (&EdgeIndex, &u64)> + '_ {
-        std::iter::zip(&self.legs, &self.bond_dims)
-    }
-
-    /// Returns the nested tensors of a composite tensor.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
-    /// # use rustc_hash::FxHashMap;
-    /// let bond_dims = FxHashMap::from_iter([(0, 17), (1, 19), (2, 8)]);
-    /// let v1 = Tensor::new_from_map(vec![0, 1], &bond_dims);
-    /// let v2 = Tensor::new_from_map(vec![1, 2], &bond_dims);
-    /// let tn = Tensor::new_composite(vec![v1.clone(), v2.clone()]);
-    /// for (tensor, ref_tensor) in std::iter::zip(tn.tensors(), vec![v1, v2]){
-    ///    assert_eq!(tensor.legs(), ref_tensor.legs());
-    /// }
-    /// ```
-    #[inline]
-    pub fn tensors(&self) -> &Vec<Self> {
-        &self.tensors
-    }
-
-    /// Gets a nested `Tensor` based on the `nested_indices` which specify the index
-    /// of the tensor at each level of the hierarchy.
-    ///
-    /// # Examples
-    /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
-    /// # use rustc_hash::FxHashMap;
-    /// let bond_dims = FxHashMap::from_iter([(0, 17), (1, 19), (2, 8), (3, 2), (4, 1)]);
-    /// let mut v1 = Tensor::new_from_map(vec![0, 1], &bond_dims);
-    /// let mut v2 = Tensor::new_from_map(vec![1, 2], &bond_dims);
-    /// let mut v3 = Tensor::new_from_map(vec![2, 3], &bond_dims);
-    /// let mut v4 = Tensor::new_from_map(vec![3, 4], &bond_dims);
-    /// let tn1 = Tensor::new_composite(vec![v1, v2]);
-    /// let tn2 = Tensor::new_composite(vec![v3.clone(), v4]);
-    /// let nested_tn = Tensor::new_composite(vec![tn1, tn2]);
-    ///
-    /// assert_eq!(nested_tn.nested_tensor(&[1, 0]).legs(), v3.legs());
-    /// ```
-    pub fn nested_tensor(&self, nested_indices: &[usize]) -> &Tensor {
-        let mut tensor = self;
-        for index in nested_indices {
-            tensor = tensor.tensor(*index);
-        }
-        tensor
-    }
-
-    /// Returns the total number of leaf tensors in the hierarchy.
-    pub fn total_num_tensors(&self) -> usize {
-        if self.is_composite() {
-            self.tensors.iter().map(Self::total_num_tensors).sum()
-        } else {
-            1
-        }
-    }
-
-    /// Get ith Tensor.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
-    /// # use rustc_hash::FxHashMap;
-    /// let bond_dims = FxHashMap::from_iter([(0, 17), (1, 19), (2, 8)]);
-    /// let v1 = Tensor::new_from_map(vec![0, 1], &bond_dims);
-    /// let v2 = Tensor::new_from_map(vec![1, 2], &bond_dims);
-    /// let tn = Tensor::new_composite(vec![v1.clone(), v2]);
-    /// assert_eq!(tn.tensor(0).legs(), v1.legs());
-    /// ```
-    #[inline]
-    pub fn tensor(&self, i: TensorIndex) -> &Self {
-        &self.tensors[i]
+    pub fn edges(&self) -> impl Iterator<Item = (EdgeIndex, u64)> + '_ {
+        std::iter::zip(
+            self.0.legs.iter().copied(),
+            self.0.bond_dims.iter().copied(),
+        )
     }
 
     /// Getter for bond dimensions.
     #[inline]
     pub fn bond_dims(&self) -> &Vec<u64> {
-        assert!(self.is_leaf());
-        &self.bond_dims
+        &self.0.bond_dims
     }
 
     /// Returns the shape of tensor. This is the same as the bond dimensions, but as
     /// `usize`. The conversion can fail, hence a [`Result`] is returned.
     pub fn shape(&self) -> Result<Vec<usize>, TryFromIntError> {
-        self.bond_dims.iter().map(|&dim| dim.try_into()).collect()
+        self.0.bond_dims.iter().map(|&dim| dim.try_into()).collect()
     }
 
     /// Returns the number of dimensions.
     ///
     /// # Examples
     /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
+    /// # use tnc::tensornetwork::tensor::LeafTensor;
     /// # use rustc_hash::FxHashMap;
     /// let bond_dims = FxHashMap::from_iter([(1, 4), (2, 6), (3, 2)]);
-    /// let tensor = Tensor::new_from_map(vec![1, 2, 3], &bond_dims);
+    /// let tensor = LeafTensor::new_from_map(vec![1, 2, 3], &bond_dims);
     /// assert_eq!(tensor.dims(), 3);
     /// ```
     #[inline]
     pub fn dims(&self) -> usize {
-        self.legs.len()
+        self.0.legs.len()
     }
 
     /// Returns the number of elements. This is a f64 to avoid overflow in large
@@ -223,106 +561,39 @@ impl Tensor {
     ///
     /// # Examples
     /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
+    /// # use tnc::tensornetwork::tensor::LeafTensor;
     /// # use rustc_hash::FxHashMap;
     /// let bond_dims = FxHashMap::from_iter([(1, 5), (2, 15), (3, 8)]);
-    /// let tensor = Tensor::new_from_map(vec![1, 2, 3], &bond_dims);
+    /// let tensor = LeafTensor::new_from_map(vec![1, 2, 3], &bond_dims);
     /// assert_eq!(tensor.size(), 600.0);
     /// ```
     #[inline]
     pub fn size(&self) -> f64 {
-        self.bond_dims.iter().map(|v| *v as f64).product()
+        self.0.bond_dims.iter().map(|v| *v as f64).product()
     }
 
-    /// Returns true if Tensor is a leaf tensor, without any nested tensors.
-    ///
-    /// # Examples
-    /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
-    /// # use rustc_hash::FxHashMap;
-    /// let bond_dims = FxHashMap::from_iter([(1, 2), (2, 4), (3, 6)]);
-    /// let tensor = Tensor::new_from_map(vec![1, 2, 3], &bond_dims);
-    /// assert_eq!(tensor.is_leaf(), true);
-    /// let comp = Tensor::new_composite(vec![tensor]);
-    /// assert_eq!(comp.is_leaf(), false);
-    /// ```
+    /// Converts this tensor into the leg ids and bond dimensions it is made of.
     #[inline]
-    pub fn is_leaf(&self) -> bool {
-        self.tensors.is_empty()
+    pub fn into_legs(self) -> Vec<EdgeIndex> {
+        self.0.legs
     }
 
-    /// Returns true if Tensor is composite.
-    ///
-    /// # Examples
-    /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
-    /// # use rustc_hash::FxHashMap;
-    /// let bond_dims = FxHashMap::from_iter([(1, 2), (2, 4), (3, 6)]);
-    /// let tensor = Tensor::new_from_map(vec![1, 2, 3], &bond_dims);
-    /// assert_eq!(tensor.is_composite(), false);
-    /// let comp = Tensor::new_composite(vec![tensor]);
-    /// assert_eq!(comp.is_composite(), true);
-    /// ```
+    /// Converts this tensor into the data it contains.
     #[inline]
-    pub fn is_composite(&self) -> bool {
-        !self.tensors.is_empty()
+    pub fn into_data(self) -> TensorData {
+        self.0.tensordata
     }
 
-    /// Returns true if Tensor is empty. This means, it doesn't have any subtensors,
-    /// has no legs and is doesn't have any data (e.g., is not a scalar).
-    ///
-    /// # Examples
-    /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
-    /// let tensor = Tensor::default();
-    /// assert_eq!(tensor.is_empty(), true);
-    /// ```
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.tensors.is_empty()
-            && self.legs.is_empty()
-            && matches!(*self.tensor_data(), TensorData::Uncontracted)
-    }
-
-    /// Consumes the `Tensor` and returns its `TensorData`.
-    ///
-    /// # Examples
-    /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
-    /// # use tnc::tensornetwork::tensordata::TensorData;
-    /// let tensor = Tensor::new_from_const(vec![1, 2], 2);
-    /// let tensordata = tensor.into_tensor_data();
-    /// assert_eq!(tensordata, TensorData::Uncontracted);
-    /// ```
-    #[inline]
-    pub fn into_tensor_data(self) -> TensorData {
-        self.tensordata
-    }
-
-    /// Pushes additional `tensor` into this tensor, which must be a composite tensor.
-    #[inline]
-    pub fn push_tensor(&mut self, tensor: Self) {
-        assert!(
-            self.legs.is_empty() && matches!(self.tensordata, TensorData::Uncontracted),
-            "Cannot push tensors into a leaf tensor"
-        );
-        self.tensors.push(tensor);
-    }
-
-    /// Pushes additional `tensors` into this tensor, which must be a composite tensor.
-    #[inline]
-    pub fn push_tensors(&mut self, mut tensors: Vec<Self>) {
-        assert!(
-            self.legs.is_empty() && matches!(self.tensordata, TensorData::Uncontracted),
-            "Cannot push tensors into a leaf tensor"
-        );
-        self.tensors.append(&mut tensors);
+    /// Converts this tensor into the leg ids, bond dimensions and data it is made
+    /// of.
+    pub fn into_inner(self) -> (Vec<EdgeIndex>, Vec<u64>, TensorData) {
+        (self.0.legs, self.0.bond_dims, self.0.tensordata)
     }
 
     /// Getter for tensor data.
     #[inline]
     pub fn tensor_data(&self) -> &TensorData {
-        &self.tensordata
+        &self.0.tensordata
     }
 
     /// Setter for tensor data.
@@ -330,195 +601,197 @@ impl Tensor {
     /// # Examples
     ///
     /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
+    /// # use tnc::tensornetwork::tensor::LeafTensor;
     /// # use tnc::tensornetwork::tensordata::TensorData;
-    /// let mut tensor = Tensor::new_from_const(vec![0, 1], 2);
+    /// let mut tensor = LeafTensor::new_from_const(vec![0, 1], 2);
     /// let tensordata = TensorData::Gate((String::from("x"), vec![], false));
     /// tensor.set_tensor_data(tensordata);
     /// ```
     #[inline]
     pub fn set_tensor_data(&mut self, tensordata: TensorData) {
-        assert!(
-            self.is_leaf() || matches!(tensordata, TensorData::Uncontracted),
-            "Cannot add data to composite tensor"
-        );
-        self.tensordata = tensordata;
+        self.0.tensordata = tensordata;
     }
 
-    /// Returns whether all tensors inside this tensor are connected.
-    /// This only checks the top-level, not recursing into composite tensors.
+    /// Returns the tensor with legs in `self` that are not in `other`.
     ///
     /// # Examples
     /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
-    /// # use rustc_hash::FxHashMap;
-    /// // Create a tensor network with two connected tensors
-    /// let bond_dims = FxHashMap::from_iter([(0, 17), (1, 19), (2, 8), (3, 5)]);
-    /// let v1 = Tensor::new_from_map(vec![0, 1], &bond_dims);
-    /// let v2 = Tensor::new_from_map(vec![1, 2], &bond_dims);
-    /// let mut tn = Tensor::new_composite(vec![v1, v2]);
-    /// assert!(tn.is_connected());
-    ///
-    /// // Introduce a new tensor that is not connected
-    /// let v3 = Tensor::new_from_map(vec![3], &bond_dims);
-    /// tn.push_tensor(v3);
-    /// assert!(!tn.is_connected());
-    /// ```
-    pub fn is_connected(&self) -> bool {
-        let num_tensors = self.tensors.len();
-        let mut uf = UnionFind::new(num_tensors);
-
-        for t1_id in 0..num_tensors {
-            for t2_id in (t1_id + 1)..num_tensors {
-                let t1 = &self.tensors[t1_id];
-                let t2 = &self.tensors[t2_id];
-                if !(t1 & t2).legs.is_empty() {
-                    uf.union(t1_id, t2_id);
-                }
-            }
-        }
-
-        uf.count_sets() == 1
-    }
-
-    /// Returns `Tensor` with legs in `self` that are not in `other`.
-    ///
-    /// # Examples
-    /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
+    /// # use tnc::tensornetwork::tensor::LeafTensor;
     /// # use rustc_hash::FxHashMap;
     /// let bond_dims = FxHashMap::from_iter([(1, 2), (2, 4), (3, 6), (4, 3), (5, 9)]);
-    /// let tensor1 = Tensor::new_from_map(vec![1, 2, 3], &bond_dims);
-    /// let tensor2 = Tensor::new_from_map(vec![4, 2, 5], &bond_dims);
+    /// let tensor1 = LeafTensor::new_from_map(vec![1, 2, 3], &bond_dims);
+    /// let tensor2 = LeafTensor::new_from_map(vec![4, 2, 5], &bond_dims);
     /// let diff_tensor = &tensor1 - &tensor2;
     /// assert_eq!(diff_tensor.legs(), &[1, 3]);
     /// assert_eq!(diff_tensor.bond_dims(), &[2, 6]);
     /// ```
     #[must_use]
     pub fn difference(&self, other: &Self) -> Self {
-        let mut new_legs = Vec::with_capacity(self.legs.len());
+        let mut new_legs = Vec::with_capacity(self.legs().len());
         let mut new_bond_dims = Vec::with_capacity(new_legs.capacity());
         for (leg, dim) in self.edges() {
-            if !other.legs.contains(leg) {
-                new_legs.push(*leg);
-                new_bond_dims.push(*dim);
+            if !other.legs().contains(&leg) {
+                new_legs.push(leg);
+                new_bond_dims.push(dim);
             }
         }
         Self::new(new_legs, new_bond_dims)
     }
 
-    /// Returns `Tensor` with union of legs in both `self` and `other`.
+    /// Returns the tensor with union of legs in both `self` and `other`.
     ///
     /// # Examples
     /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
+    /// # use tnc::tensornetwork::tensor::LeafTensor;
     /// # use rustc_hash::FxHashMap;
     /// let bond_dims = FxHashMap::from_iter([(1, 2), (2, 4), (3, 6), (4, 3), (5, 9)]);
-    /// let tensor1 = Tensor::new_from_map(vec![1, 2, 3], &bond_dims);
-    /// let tensor2 = Tensor::new_from_map(vec![4, 2, 5], &bond_dims);
+    /// let tensor1 = LeafTensor::new_from_map(vec![1, 2, 3], &bond_dims);
+    /// let tensor2 = LeafTensor::new_from_map(vec![4, 2, 5], &bond_dims);
     /// let union_tensor = &tensor1 | &tensor2;
     /// assert_eq!(union_tensor.legs(), &[1, 2, 3, 4, 5]);
     /// assert_eq!(union_tensor.bond_dims(), &[2, 4, 6, 3, 9]);
     /// ```
     #[must_use]
     pub fn union(&self, other: &Self) -> Self {
-        let mut new_legs = Vec::with_capacity(self.legs.len() + other.legs.len());
+        let mut new_legs = Vec::with_capacity(self.legs().len() + other.legs().len());
         let mut new_bond_dims = Vec::with_capacity(new_legs.capacity());
-        new_legs.extend_from_slice(&self.legs);
-        new_bond_dims.extend_from_slice(&self.bond_dims);
+        new_legs.extend_from_slice(self.legs());
+        new_bond_dims.extend_from_slice(self.bond_dims());
         for (leg, dim) in other.edges() {
-            if !self.legs.contains(leg) {
-                new_legs.push(*leg);
-                new_bond_dims.push(*dim);
+            if !self.legs().contains(&leg) {
+                new_legs.push(leg);
+                new_bond_dims.push(dim);
             }
         }
         Self::new(new_legs, new_bond_dims)
     }
 
-    /// Returns `Tensor` with intersection of legs in `self` and `other`.
+    /// Returns the tensor with intersection of legs in `self` and `other`.
     ///
     /// # Examples
     /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
+    /// # use tnc::tensornetwork::tensor::LeafTensor;
     /// # use rustc_hash::FxHashMap;
     /// let bond_dims = FxHashMap::from_iter([(1, 2), (2, 4), (3, 6), (4, 3), (5, 9)]);
-    /// let tensor1 = Tensor::new_from_map(vec![1, 2, 3], &bond_dims);
-    /// let tensor2 = Tensor::new_from_map(vec![4, 2, 5], &bond_dims);
+    /// let tensor1 = LeafTensor::new_from_map(vec![1, 2, 3], &bond_dims);
+    /// let tensor2 = LeafTensor::new_from_map(vec![4, 2, 5], &bond_dims);
     /// let intersection_tensor = &tensor1 & &tensor2;
     /// assert_eq!(intersection_tensor.legs(), &[2]);
     /// assert_eq!(intersection_tensor.bond_dims(), &[4]);
     /// ```
     #[must_use]
     pub fn intersection(&self, other: &Self) -> Self {
-        let mut new_legs = Vec::with_capacity(self.legs.len().min(other.legs.len()));
+        let mut new_legs = Vec::with_capacity(self.legs().len().min(other.legs().len()));
         let mut new_bond_dims = Vec::with_capacity(new_legs.capacity());
         for (leg, dim) in self.edges() {
-            if other.legs.contains(leg) {
-                new_legs.push(*leg);
-                new_bond_dims.push(*dim);
+            if other.legs().contains(&leg) {
+                new_legs.push(leg);
+                new_bond_dims.push(dim);
             }
         }
         Self::new(new_legs, new_bond_dims)
     }
 
-    /// Returns `Tensor` with symmetrical difference of legs in `self` and `other`.
+    /// Returns the tensor with symmetrical difference of legs in `self` and `other`.
     ///
     /// # Examples
     /// ```
-    /// # use tnc::tensornetwork::tensor::Tensor;
+    /// # use tnc::tensornetwork::tensor::LeafTensor;
     /// # use rustc_hash::FxHashMap;
     /// let bond_dims = FxHashMap::from_iter([(1, 2), (2, 4), (3, 6), (4, 3), (5, 9)]);
-    /// let tensor1 = Tensor::new_from_map(vec![1, 2, 3], &bond_dims);
-    /// let tensor2 = Tensor::new_from_map(vec![4, 2, 5], &bond_dims);
+    /// let tensor1 = LeafTensor::new_from_map(vec![1, 2, 3], &bond_dims);
+    /// let tensor2 = LeafTensor::new_from_map(vec![4, 2, 5], &bond_dims);
     /// let sym_dif_tensor = &tensor1 ^ &tensor2;
     /// assert_eq!(sym_dif_tensor.legs(), &[1, 3, 4, 5]);
     /// assert_eq!(sym_dif_tensor.bond_dims(), &[2, 6, 3, 9]);
     /// ```
     #[must_use]
     pub fn symmetric_difference(&self, other: &Self) -> Self {
-        let mut new_legs = Vec::with_capacity(self.legs.len() + other.legs.len());
+        let mut new_legs = Vec::with_capacity(self.legs().len() + other.legs().len());
         let mut new_bond_dims = Vec::with_capacity(new_legs.capacity());
         for (leg, dim) in self.edges() {
-            if !other.legs.contains(leg) {
-                new_legs.push(*leg);
-                new_bond_dims.push(*dim);
+            if !other.legs().contains(&leg) {
+                new_legs.push(leg);
+                new_bond_dims.push(dim);
             }
         }
         for (leg, dim) in other.edges() {
-            if !self.legs.contains(leg) {
-                new_legs.push(*leg);
-                new_bond_dims.push(*dim);
+            if !self.legs().contains(&leg) {
+                new_legs.push(leg);
+                new_bond_dims.push(dim);
             }
         }
         Self::new(new_legs, new_bond_dims)
     }
+}
 
-    /// Get output legs after tensor contraction
-    pub fn external_tensor(&self) -> Tensor {
-        if self.is_leaf() {
-            return self.clone();
-        }
-
-        let mut ext_tensor = Self::default();
-        for tensor in &self.tensors {
-            let new_tensor = if tensor.is_composite() {
-                &tensor.external_tensor()
-            } else {
-                tensor
-            };
-            ext_tensor = &ext_tensor ^ new_tensor;
-        }
-
-        ext_tensor
+impl Default for LeafTensor {
+    fn default() -> Self {
+        Self(TensorRepr {
+            kind: TensorType::Leaf,
+            tensors: Vec::new(),
+            legs: Vec::new(),
+            bond_dims: Vec::new(),
+            tensordata: TensorData::None,
+        })
     }
 }
 
-impl PartialEq for Tensor {
-    fn eq(&self, other: &Self) -> bool {
-        self.legs == other.legs
-            && self.bond_dims == other.bond_dims
-            && self.tensors == other.tensors
-            && self.tensordata == other.tensordata
+impl BitOr for &LeafTensor {
+    type Output = LeafTensor;
+    #[inline]
+    fn bitor(self, rhs: Self) -> Self::Output {
+        self.union(rhs)
+    }
+}
+
+impl BitAnd for &LeafTensor {
+    type Output = LeafTensor;
+    #[inline]
+    fn bitand(self, rhs: Self) -> Self::Output {
+        self.intersection(rhs)
+    }
+}
+
+impl BitXor for &LeafTensor {
+    type Output = LeafTensor;
+    #[inline]
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        self.symmetric_difference(rhs)
+    }
+}
+
+impl Sub for &LeafTensor {
+    type Output = LeafTensor;
+    #[inline]
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.difference(rhs)
+    }
+}
+
+impl BitXorAssign<&LeafTensor> for LeafTensor {
+    #[inline]
+    fn bitxor_assign(&mut self, rhs: &Self) {
+        *self = self.symmetric_difference(rhs);
+    }
+}
+
+impl AbsDiffEq for LeafTensor {
+    type Epsilon = f64;
+
+    fn default_epsilon() -> Self::Epsilon {
+        f64::EPSILON
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        if self.legs() != other.legs() {
+            return false;
+        }
+        if self.bond_dims() != other.bond_dims() {
+            return false;
+        }
+
+        TensorData::abs_diff_eq(self.tensor_data(), other.tensor_data(), epsilon)
     }
 }
 
@@ -530,61 +803,19 @@ impl AbsDiffEq for Tensor {
     }
 
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        if self.legs != other.legs {
-            return false;
-        }
-        if self.bond_dims != other.bond_dims {
-            return false;
-        }
-        if self.tensors.len() != other.tensors.len() {
-            return false;
-        }
-        for (tensor, other_tensor) in zip(&self.tensors, &other.tensors) {
-            if !Tensor::abs_diff_eq(tensor, other_tensor, epsilon) {
-                return false;
+        match (self.kind(), other.kind()) {
+            (TensorType::Leaf, TensorType::Leaf) => {
+                let self_leaf = self.as_leaf().unwrap();
+                let other_leaf = other.as_leaf().unwrap();
+                LeafTensor::abs_diff_eq(self_leaf, other_leaf, epsilon)
             }
+            (TensorType::Composite, TensorType::Composite) => {
+                let self_comp = self.as_composite().unwrap();
+                let other_comp = other.as_composite().unwrap();
+                CompositeTensor::abs_diff_eq(self_comp, other_comp, epsilon)
+            }
+            _ => false,
         }
-
-        TensorData::abs_diff_eq(&self.tensordata, &other.tensordata, epsilon)
-    }
-}
-
-impl BitOr for &Tensor {
-    type Output = Tensor;
-    #[inline]
-    fn bitor(self, rhs: &Tensor) -> Tensor {
-        self.union(rhs)
-    }
-}
-
-impl BitAnd for &Tensor {
-    type Output = Tensor;
-    #[inline]
-    fn bitand(self, rhs: &Tensor) -> Tensor {
-        self.intersection(rhs)
-    }
-}
-
-impl BitXor for &Tensor {
-    type Output = Tensor;
-    #[inline]
-    fn bitxor(self, rhs: &Tensor) -> Tensor {
-        self.symmetric_difference(rhs)
-    }
-}
-
-impl Sub for &Tensor {
-    type Output = Tensor;
-    #[inline]
-    fn sub(self, rhs: &Tensor) -> Tensor {
-        self.difference(rhs)
-    }
-}
-
-impl BitXorAssign<&Tensor> for Tensor {
-    #[inline]
-    fn bitxor_assign(&mut self, rhs: &Tensor) {
-        *self = self.symmetric_difference(rhs);
     }
 }
 
@@ -594,7 +825,6 @@ mod tests {
 
     use std::iter::zip;
 
-    use approx::assert_abs_diff_eq;
     use rustc_hash::FxHashMap;
 
     use crate::tensornetwork::tensordata::TensorData;
@@ -612,141 +842,132 @@ mod tests {
         };
     }
 
-    #[test]
-    fn test_empty_tensor() {
-        let tensor = Tensor::default();
-        assert!(tensor.tensors.is_empty());
-        assert!(tensor.legs.is_empty());
-        assert!(tensor.bond_dims.is_empty());
-        assert!(tensor.is_empty());
-    }
+    mod leaf {
+        use super::*;
 
-    #[test]
-    fn test_new() {
-        let tensor = Tensor::new(vec![2, 4, 5], vec![4, 2, 6]);
-        assert_eq!(tensor.legs(), &[2, 4, 5]);
-        assert_eq!(tensor.bond_dims(), &[4, 2, 6]);
-        assert_matches!(tensor.tensor_data(), TensorData::Uncontracted);
-    }
-
-    #[test]
-    fn test_new_from_map() {
-        let bond_dims = FxHashMap::from_iter([(1, 1), (2, 4), (3, 7), (4, 2), (5, 6)]);
-        let tensor = Tensor::new_from_map(vec![2, 4, 5], &bond_dims);
-        assert_eq!(tensor.legs(), &[2, 4, 5]);
-        assert_eq!(tensor.bond_dims(), &[4, 2, 6]);
-        assert_matches!(tensor.tensor_data(), TensorData::Uncontracted);
-    }
-
-    #[test]
-    fn test_new_from_const() {
-        let tensor = Tensor::new_from_const(vec![9, 2, 5, 1], 3);
-        assert_eq!(tensor.legs(), &[9, 2, 5, 1]);
-        assert_eq!(tensor.bond_dims(), &[3, 3, 3, 3]);
-        assert_matches!(tensor.tensor_data(), TensorData::Uncontracted);
-    }
-
-    #[test]
-    fn test_external_tensor() {
-        let bond_dims = FxHashMap::from_iter([
-            (2, 2),
-            (3, 4),
-            (4, 6),
-            (5, 8),
-            (6, 10),
-            (7, 12),
-            (8, 14),
-            (9, 16),
-        ]);
-        let tensor_1 = Tensor::new_from_map(vec![2, 3, 4], &bond_dims);
-        let tensor_2 = Tensor::new_from_map(vec![2, 3, 5], &bond_dims);
-        let tensor_12 = Tensor::new_composite(vec![tensor_1, tensor_2]);
-
-        let tensor_3 = Tensor::new_from_map(vec![6, 7, 8], &bond_dims);
-        let tensor_4 = Tensor::new_from_map(vec![6, 8, 9], &bond_dims);
-        let tensor_34 = Tensor::new_composite(vec![tensor_3, tensor_4]);
-
-        let tensor_1234 = Tensor::new_composite(vec![tensor_12, tensor_34]);
-
-        let external = tensor_1234.external_tensor();
-
-        let ref_tensor = Tensor::new_from_map(vec![4, 5, 7, 9], &bond_dims);
-        assert_abs_diff_eq!(&external, &ref_tensor);
-    }
-
-    #[test]
-    fn test_push_tensor() {
-        let bond_dims =
-            FxHashMap::from_iter([(2, 17), (3, 1), (4, 11), (8, 3), (9, 20), (7, 7), (10, 14)]);
-        let ref_tensor_1 = Tensor::new_from_map(vec![8, 4, 9], &bond_dims);
-        let ref_tensor_2 = Tensor::new_from_map(vec![7, 10, 2], &bond_dims);
-
-        let mut tensor = Tensor::default();
-
-        // Push tensor 1
-        let tensor_1 = Tensor::new_from_map(vec![8, 4, 9], &bond_dims);
-        tensor.push_tensor(tensor_1);
-
-        for (sub_tensor, ref_tensor) in zip(tensor.tensors(), [&ref_tensor_1]) {
-            assert_abs_diff_eq!(sub_tensor, ref_tensor);
+        #[test]
+        fn default() {
+            let tensor = LeafTensor::default();
+            assert!(tensor.legs().is_empty());
+            assert!(tensor.bond_dims().is_empty());
+            assert_matches!(tensor.tensor_data(), TensorData::None);
         }
 
-        // Push tensor 2
-        let tensor_2 = Tensor::new_from_map(vec![7, 10, 2], &bond_dims);
-        tensor.push_tensor(tensor_2);
-
-        for (sub_tensor, ref_tensor) in zip(tensor.tensors(), [&ref_tensor_1, &ref_tensor_2]) {
-            assert_abs_diff_eq!(sub_tensor, ref_tensor);
+        #[test]
+        fn new() {
+            let tensor = LeafTensor::new(vec![2, 4, 5], vec![4, 2, 6]);
+            assert_eq!(tensor.legs(), &[2, 4, 5]);
+            assert_eq!(tensor.bond_dims(), &[4, 2, 6]);
+            assert_matches!(tensor.tensor_data(), TensorData::None);
         }
 
-        // Test that other fields are unchanged
-        assert_matches!(tensor.tensor_data(), TensorData::Uncontracted);
-        assert!(tensor.legs().is_empty());
-    }
+        #[test]
+        fn new_from_map() {
+            let bond_dims = FxHashMap::from_iter([(1, 1), (2, 4), (3, 7), (4, 2), (5, 6)]);
+            let tensor = LeafTensor::new_from_map(vec![2, 4, 5], &bond_dims);
+            assert_eq!(tensor.legs(), &[2, 4, 5]);
+            assert_eq!(tensor.bond_dims(), &[4, 2, 6]);
+            assert_matches!(tensor.tensor_data(), TensorData::None);
+        }
 
-    #[test]
-    #[should_panic(expected = "Cannot push tensors into a leaf tensor")]
-    fn test_push_tensor_to_leaf() {
-        let bond_dims =
-            FxHashMap::from_iter([(2, 17), (3, 1), (4, 11), (8, 3), (9, 20), (7, 7), (10, 14)]);
-        let mut leaf_tensor = Tensor::new_from_map(vec![4, 3, 2], &bond_dims);
-        let pushed_tensor = Tensor::new_from_map(vec![8, 4, 9], &bond_dims);
-        leaf_tensor.push_tensor(pushed_tensor);
-    }
-
-    #[test]
-    fn test_push_tensors() {
-        let bond_dims =
-            FxHashMap::from_iter([(2, 17), (3, 1), (4, 11), (8, 3), (9, 20), (7, 7), (10, 14)]);
-        let ref_tensor_1 = Tensor::new_from_map(vec![4, 3, 2], &bond_dims);
-        let ref_tensor_2 = Tensor::new_from_map(vec![8, 4, 9], &bond_dims);
-        let ref_tensor_3 = Tensor::new_from_map(vec![7, 10, 2], &bond_dims);
-
-        let tensor_1 = Tensor::new_from_map(vec![4, 3, 2], &bond_dims);
-        let tensor_2 = Tensor::new_from_map(vec![8, 4, 9], &bond_dims);
-        let tensor_3 = Tensor::new_from_map(vec![7, 10, 2], &bond_dims);
-        let mut tensor = Tensor::default();
-        tensor.push_tensors(vec![tensor_1, tensor_2, tensor_3]);
-
-        assert_matches!(tensor.tensor_data(), TensorData::Uncontracted);
-
-        for (sub_tensor, ref_tensor) in zip(
-            tensor.tensors(),
-            &vec![ref_tensor_1, ref_tensor_2, ref_tensor_3],
-        ) {
-            assert_abs_diff_eq!(sub_tensor, ref_tensor);
+        #[test]
+        fn new_from_const() {
+            let tensor = LeafTensor::new_from_const(vec![9, 2, 5, 1], 3);
+            assert_eq!(tensor.legs(), &[9, 2, 5, 1]);
+            assert_eq!(tensor.bond_dims(), &[3, 3, 3, 3]);
+            assert_matches!(tensor.tensor_data(), TensorData::None);
         }
     }
 
-    #[test]
-    #[should_panic(expected = "Cannot push tensors into a leaf tensor")]
-    fn test_push_tensors_to_leaf() {
-        let bond_dims =
-            FxHashMap::from_iter([(2, 17), (3, 1), (4, 11), (8, 3), (9, 20), (7, 7), (10, 14)]);
-        let mut leaf_tensor = Tensor::new_from_map(vec![4, 3, 2], &bond_dims);
-        let pushed_tensor_1 = Tensor::new_from_map(vec![8, 4, 9], &bond_dims);
-        let pushed_tensor_2 = Tensor::new_from_map(vec![7, 10, 2], &bond_dims);
+    mod composite {
+        use super::*;
 
-        leaf_tensor.push_tensors(vec![pushed_tensor_1, pushed_tensor_2]);
+        #[test]
+        fn default() {
+            let tensor = CompositeTensor::default();
+            assert!(tensor.is_empty());
+            assert_eq!(tensor.len(), 0);
+        }
+
+        #[test]
+        fn external_tensor() {
+            let bond_dims = FxHashMap::from_iter([
+                (2, 2),
+                (3, 4),
+                (4, 6),
+                (5, 8),
+                (6, 10),
+                (7, 12),
+                (8, 14),
+                (9, 16),
+            ]);
+            let tensor_1 = LeafTensor::new_from_map(vec![2, 3, 4], &bond_dims);
+            let tensor_2 = LeafTensor::new_from_map(vec![2, 3, 5], &bond_dims);
+            let tensor_12 = CompositeTensor::new(vec![tensor_1, tensor_2]);
+
+            let tensor_3 = LeafTensor::new_from_map(vec![6, 7, 8], &bond_dims);
+            let tensor_4 = LeafTensor::new_from_map(vec![6, 8, 9], &bond_dims);
+            let tensor_34 = CompositeTensor::new(vec![tensor_3, tensor_4]);
+
+            let tensor_1234 = CompositeTensor::new(vec![tensor_12, tensor_34]);
+
+            let external = tensor_1234.external_tensor();
+            assert_eq!(external.legs(), &[4, 5, 7, 9]);
+            assert_eq!(external.bond_dims(), &[6, 8, 12, 16]);
+        }
+
+        #[test]
+        fn test_push_tensor() {
+            let bond_dims =
+                FxHashMap::from_iter([(2, 17), (3, 1), (4, 11), (8, 3), (9, 20), (7, 7), (10, 14)]);
+            let ref_tensor_1 = LeafTensor::new_from_map(vec![8, 4, 9], &bond_dims);
+            let ref_tensor_2 = LeafTensor::new_from_map(vec![7, 10, 2], &bond_dims);
+
+            let mut tensor = CompositeTensor::default();
+
+            // Push tensor 1
+            let tensor_1 = LeafTensor::new_from_map(vec![8, 4, 9], &bond_dims);
+            tensor.push_tensor(tensor_1);
+
+            for (sub_tensor, ref_tensor) in zip(tensor.tensors(), [&ref_tensor_1]) {
+                let sub_tensor = sub_tensor.as_leaf().unwrap();
+                assert_eq!(sub_tensor.legs(), ref_tensor.legs());
+                assert_eq!(sub_tensor.bond_dims(), ref_tensor.bond_dims());
+            }
+
+            // Push tensor 2
+            let tensor_2 = LeafTensor::new_from_map(vec![7, 10, 2], &bond_dims);
+            tensor.push_tensor(tensor_2);
+
+            for (sub_tensor, ref_tensor) in zip(tensor.tensors(), [&ref_tensor_1, &ref_tensor_2]) {
+                let sub_tensor = sub_tensor.as_leaf().unwrap();
+                assert_eq!(sub_tensor.legs(), ref_tensor.legs());
+                assert_eq!(sub_tensor.bond_dims(), ref_tensor.bond_dims());
+            }
+        }
+
+        #[test]
+        fn test_push_tensors() {
+            let bond_dims =
+                FxHashMap::from_iter([(2, 17), (3, 1), (4, 11), (8, 3), (9, 20), (7, 7), (10, 14)]);
+            let ref_tensor_1 = LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims);
+            let ref_tensor_2 = LeafTensor::new_from_map(vec![8, 4, 9], &bond_dims);
+            let ref_tensor_3 = LeafTensor::new_from_map(vec![7, 10, 2], &bond_dims);
+
+            let tensor_1 = LeafTensor::new_from_map(vec![4, 3, 2], &bond_dims);
+            let tensor_2 = LeafTensor::new_from_map(vec![8, 4, 9], &bond_dims);
+            let tensor_3 = LeafTensor::new_from_map(vec![7, 10, 2], &bond_dims);
+            let mut tensor = CompositeTensor::default();
+            tensor.push_tensors(vec![tensor_1, tensor_2, tensor_3]);
+
+            for (sub_tensor, ref_tensor) in zip(
+                tensor.tensors(),
+                &vec![ref_tensor_1, ref_tensor_2, ref_tensor_3],
+            ) {
+                let sub_tensor = sub_tensor.as_leaf().unwrap();
+                assert_eq!(sub_tensor.legs(), ref_tensor.legs());
+                assert_eq!(sub_tensor.bond_dims(), ref_tensor.bond_dims());
+            }
+        }
     }
 }

--- a/tnc/src/tensornetwork/tensordata.rs
+++ b/tnc/src/tensornetwork/tensordata.rs
@@ -15,10 +15,9 @@ pub type DataTensor = ArrayD<Complex64>;
 /// The data of a tensor.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TensorData {
-    /// This is for composite tensors that have not been contracted yet, as well as
-    /// empty tensors in general.
+    /// No data.
     #[default]
-    Uncontracted,
+    None,
     /// The data is loaded from a HDF5 file.
     File((PathBuf, bool)),
     /// A quantum gate. The name must be registered in the gates module.
@@ -37,7 +36,7 @@ impl TensorData {
     /// Consumes the tensor data and returns the contained tensor.
     pub fn into_data(self) -> DataTensor {
         match self {
-            TensorData::Uncontracted => panic!("Cannot convert uncontracted tensor to data"),
+            TensorData::None => panic!("Cannot convert uncontracted tensor to data"),
             TensorData::File((filename, adjoint)) => {
                 let mut data = load_data(filename).unwrap();
                 if adjoint {
@@ -59,7 +58,7 @@ impl TensorData {
     /// Returns the adjoint of this data.
     pub fn adjoint(self) -> Self {
         match self {
-            TensorData::Uncontracted => TensorData::Uncontracted,
+            TensorData::None => TensorData::None,
             TensorData::File((filename, adjoint)) => TensorData::File((filename, !adjoint)),
             TensorData::Gate((name, params, adjoint)) => TensorData::Gate((name, params, !adjoint)),
             TensorData::Matrix(mut tensor) => {
@@ -94,7 +93,7 @@ impl AbsDiffEq for TensorData {
             (TensorData::Matrix(l0), TensorData::Matrix(r0)) => {
                 DataTensor::abs_diff_eq(l0, r0, epsilon)
             }
-            (TensorData::Uncontracted, TensorData::Uncontracted) => true,
+            (TensorData::None, TensorData::None) => true,
             _ => false,
         }
     }

--- a/tnc/tests/integration_tests.rs
+++ b/tnc/tests/integration_tests.rs
@@ -142,9 +142,9 @@ fn test_partitioned_contraction_need_mpi() {
         Default::default()
     };
 
-    let (mut local_tn, local_path, comm) =
+    let (local_tn, local_path, comm) =
         scatter_tensor_network(&partitioned_tn, &path, rank, size, &world);
-    local_tn = contract_tensor_network(local_tn, &local_path);
+    let mut local_tn = contract_tensor_network(local_tn, &local_path);
 
     let mut communication_path = if rank == 0 {
         path.toplevel
@@ -192,7 +192,7 @@ fn dj_4qubits_statevector() {
 
     let final_tensor = contract_tensor_network(tensor_network, &path);
     let statevector = permutator.apply(final_tensor);
-    let data = statevector.into_tensor_data().into_data();
+    let data = statevector.into_data().into_data();
 
     // Result is 1/sqrt(2) * (|1110> - |1111>)
     let expected = array![
@@ -237,7 +237,7 @@ fn qft_2qubits_expectation() {
     let path = result.replace_path();
 
     let final_tensor = contract_tensor_network(tensor_network, &path);
-    let data = final_tensor.into_tensor_data().into_data();
+    let data = final_tensor.into_data().into_data();
 
     let expected = array![Complex64::new(0.5, 0.0)];
     assert_abs_diff_eq!(data.flatten(), expected, epsilon = 1e-15);


### PR DESCRIPTION
This makes intent clearer. For example, the contract method can now take a composite tensor as input and return a leaf tensor. At the same time, this also prevents bugs that were possible before, such as trying to get the children of a leaf tensor or trying to get the data of a composite tensor.