### PR TITLE
Fix order of legs in circuit append_gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- A wrong leg order bug in `CircuitBuilder` that could lead to wrong order of statevectors
+
 ## [1.0.0] - 2026-05-08
 
 Initial release, including

--- a/tnc/src/builders/circuit_builder.rs
+++ b/tnc/src/builders/circuit_builder.rs
@@ -211,11 +211,11 @@ impl Circuit {
         // Get the old and new edges
         let old_edges = indices.iter().map(|q| self.open_edges[q.index]);
         let new_edges = (0..indices.len()).map(|e| e + self.next_edge);
-        let edges = old_edges.chain(new_edges).collect_vec();
+        let edges = new_edges.chain(old_edges).collect_vec();
         self.next_edge += indices.len();
 
         // Update the open edges
-        for (q, next_edge) in indices.iter().zip(&edges[indices.len()..]) {
+        for (q, next_edge) in indices.iter().zip(&edges[..indices.len()]) {
             self.open_edges[q.index] = *next_edge;
         }
 
@@ -349,6 +349,7 @@ mod tests {
             cotengrust::{Cotengrust, OptMethod},
             FindPath,
         },
+        path,
         tensornetwork::{
             contraction::contract_tensor_network, tensor::Tensor, tensordata::TensorData,
         },
@@ -435,5 +436,34 @@ mod tests {
             TensorData::Gate((String::from("cx"), vec![], true)),
             &[qr.qubit(1), qr.qubit(1)],
         );
+    }
+
+    #[test]
+    fn dimension_order() {
+        let mut circuit = Circuit::default();
+        let qr = circuit.allocate_register(1);
+        circuit.append_gate(
+            TensorData::new_from_data(
+                &[2, 2],
+                vec![
+                    Complex64::new(1.0, 0.0),
+                    Complex64::new(2.0, 0.0),
+                    Complex64::new(3.0, 0.0),
+                    Complex64::new(4.0, 0.0),
+                ],
+                None,
+            ),
+            &[qr.qubit(0)],
+        );
+        let (tensor_network, permutor) = circuit.into_statevector_network();
+        let result = contract_tensor_network(tensor_network, &path![(0, 1)]);
+        let result = permutor.apply(result);
+        let mut tn_ref = Tensor::new_from_const(vec![1], 2);
+        tn_ref.set_tensor_data(TensorData::new_from_data(
+            &[2],
+            vec![Complex64::new(1.0, 0.0), Complex64::new(3.0, 0.0)],
+            None,
+        ));
+        assert_approx_eq!(&Tensor, &result, &tn_ref);
     }
 }

--- a/tnc/src/io/qasm/qasm_importer.rs
+++ b/tnc/src/io/qasm/qasm_importer.rs
@@ -44,7 +44,7 @@ mod tests {
     use std::f64::consts::FRAC_1_SQRT_2;
 
     use float_cmp::assert_approx_eq;
-    use num_complex::{c64, Complex64};
+    use num_complex::Complex64;
 
     use crate::{
         builders::circuit_builder::Permutor,
@@ -129,7 +129,7 @@ mod tests {
 
         // Find out which tensor is the first/top qubit (the one connected to the H gate tensor)
         // and which is the second/bottom qubit
-        let first_qubit_id = h.tensor.legs()[0];
+        let first_qubit_id = h.tensor.legs()[1];
         let (first_qubit, second_qubit) = if first_qubit_id == k0.id {
             (k0, k1)
         } else if first_qubit_id == k1.id {
@@ -140,21 +140,21 @@ mod tests {
 
         // Check edges
         let fq_to_h_id = first_qubit.tensor.legs()[0];
-        assert_eq!(h.tensor.legs()[0], fq_to_h_id);
+        assert_eq!(h.tensor.legs()[1], fq_to_h_id);
         assert!(edge_connects(fq_to_h_id, first_qubit_id, h.id, &tn));
 
         let sq_to_cx_t_id = second_qubit.tensor.legs()[0];
-        assert_eq!(cx.tensor.legs()[1], sq_to_cx_t_id);
+        assert_eq!(cx.tensor.legs()[3], sq_to_cx_t_id);
         assert!(edge_connects(sq_to_cx_t_id, second_qubit.id, cx.id, &tn));
 
-        let h_to_cx_c_id = h.tensor.legs()[1];
-        assert_eq!(cx.tensor.legs()[0], h_to_cx_c_id);
+        let h_to_cx_c_id = h.tensor.legs()[0];
+        assert_eq!(cx.tensor.legs()[2], h_to_cx_c_id);
         assert!(edge_connects(h_to_cx_c_id, h.id, cx.id, &tn));
 
-        let cx_c_to_open_id = cx.tensor.legs()[2];
+        let cx_c_to_open_id = cx.tensor.legs()[0];
         assert!(is_open_edge_of(cx_c_to_open_id, cx.id, &tn));
 
-        let cx_t_to_open_id = cx.tensor.legs()[3];
+        let cx_t_to_open_id = cx.tensor.legs()[1];
         assert!(is_open_edge_of(cx_t_to_open_id, cx.id, &tn));
     }
 
@@ -183,10 +183,10 @@ mod tests {
         let expected = TensorData::new_from_data(
             &[2, 2],
             vec![
-                c64(FRAC_1_SQRT_2, 0.),
-                c64(0, 0),
-                c64(0, 0),
-                c64(FRAC_1_SQRT_2, 0.),
+                Complex64::new(FRAC_1_SQRT_2, 0.),
+                Complex64::ZERO,
+                Complex64::ZERO,
+                Complex64::new(FRAC_1_SQRT_2, 0.),
             ],
             None,
         );
@@ -291,6 +291,35 @@ mod tests {
                 Complex64::new(0.0, -0.09564366568448116),
                 Complex64::new(-0.03678688170631573, 0.0),
                 Complex64::new(0.0, -0.24340376901515096),
+            ],
+            None,
+        );
+        assert_approx_eq!(&TensorData, &resulting_state, &expected);
+    }
+
+    #[test]
+    fn gate_order() {
+        // Ensures that the cx gate legs are in the correct order
+        let code = "OPENQASM 2.0;
+        include \"qelib1.inc\";
+        qreg q[2];
+        creg c[1];
+        u2(0,0) q[0];
+        u2(-pi,-pi) q[1];
+        cx q[0],q[1];
+        u2(-pi,-pi) q[0];";
+
+        let circuit = import_qasm(code);
+        let (tn, perm) = circuit.into_statevector_network();
+        let resulting_state = contract_tn(tn, &perm);
+
+        let expected = TensorData::new_from_data(
+            &[2, 2],
+            vec![
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(-FRAC_1_SQRT_2, 0.0),
+                Complex64::new(FRAC_1_SQRT_2, 0.0),
             ],
             None,
         );

--- a/tnc/src/tensornetwork/contraction.rs
+++ b/tnc/src/tensornetwork/contraction.rs
@@ -262,4 +262,39 @@ mod tests {
         let result = contract_tensor_network(t3, &contract_path);
         assert_approx_eq!(&Tensor, &result, &tn_ref);
     }
+
+    #[test]
+    fn dimension_order() {
+        let mut ket0 = Tensor::new_from_const(vec![0], 2);
+        ket0.set_tensor_data(TensorData::new_from_data(
+            &[2],
+            vec![Complex64::ONE, Complex64::ZERO],
+            None,
+        ));
+
+        let mut mat = Tensor::new_from_const(vec![1, 0], 2);
+        mat.set_tensor_data(TensorData::new_from_data(
+            &[2, 2],
+            vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(2.0, 0.0),
+                Complex64::new(3.0, 0.0),
+                Complex64::new(4.0, 0.0),
+            ],
+            None,
+        ));
+
+        let tn = Tensor::new_composite(vec![ket0, mat]);
+        let contract_path = path![(0, 1)];
+
+        let mut tn_ref = Tensor::new_from_const(vec![1], 2);
+        tn_ref.set_tensor_data(TensorData::new_from_data(
+            &[2],
+            vec![Complex64::new(1.0, 0.0), Complex64::new(3.0, 0.0)],
+            None,
+        ));
+
+        let result = contract_tensor_network(tn, &contract_path);
+        assert_approx_eq!(&Tensor, &result, &tn_ref);
+    }
 }


### PR DESCRIPTION
Since the gate data is given in row-major format, the outer dimension has to come first. The outer dimension should be the new edges in circuit builder. E.g., when applying the first gate, we have a matrix vector multiplication, which happens on the inner dimension. Hence, the dimension being contracted must come last. This dimension is exactly the "old_edges" in the circuit builder. Hence, the old_edges have to come last.