### PR TITLE
Use ndarray instead of tetra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Use TBLIS instead of HPTT + MKL for contraction. This means contractions are faster and often require only half as much memory. Also, build time decreased.
-
-### Removed
-- Support for column-major tensors (for now)
-- Zero-cost tensor permutations (for now)
+- Use ndarray instead of own implementation for tensors. This means more features (slicing, arbitrary memory layout, ...) and interoperability.
 
 ## [1.0.1] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Function `contract_size_tensors_bytes` to use as memory estimator. Computes the memory requirement for a contraction.
+
 ### Changed
 - Use TBLIS instead of HPTT + MKL for contraction. This means contractions are faster and often require only half as much memory. Also, build time decreased.
 - Use ndarray instead of own implementation for tensors. This means more features (slicing, arbitrary memory layout, ...) and interoperability.
+- Implement `approx` instead of `float-cmp` for tensors and tensor data
+
+### Removed
+- Function `contract_size_tensors_exact` (since there is no explicit transpose, the normal contraction size estimate is sufficient)
 
 ## [1.0.1] - 2026-05-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-complex",
+ "num-traits",
+]
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,10 +1121,11 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7c9125e8f6f10c9da3aad044cc918cf8784fa34de857b1aa68038eb05a50a9"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
+ "approx",
  "matrixmultiply",
  "num-complex",
  "num-integer",
@@ -1122,6 +1133,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+ "serde",
 ]
 
 [[package]]
@@ -1882,7 +1894,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 [[package]]
 name = "tblis"
 version = "0.1.0"
-source = "git+https://github.com/Ectras/rust-tblis#924c897b5558187319eec4faea92b56a8de33351"
+source = "git+https://github.com/Ectras/rust-tblis.git#493da087fcb40625052c4285573bffe09f58640d"
 dependencies = [
  "num-complex",
  "tblis-sys",
@@ -1891,7 +1903,7 @@ dependencies = [
 [[package]]
 name = "tblis-sys"
 version = "0.1.0"
-source = "git+https://github.com/Ectras/rust-tblis#924c897b5558187319eec4faea92b56a8de33351"
+source = "git+https://github.com/Ectras/rust-tblis.git#493da087fcb40625052c4285573bffe09f58640d"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -1899,20 +1911,6 @@ dependencies = [
  "link-cplusplus",
  "openmp-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "tetra"
-version = "0.1.0"
-source = "git+https://github.com/Ectras/tetra.git#830725a5a7ef1eff1cea0572768e38afeb0ee428"
-dependencies = [
- "bytemuck",
- "float-cmp",
- "itertools 0.14.0",
- "num-complex",
- "permutation",
- "serde",
- "tblis",
 ]
 
 [[package]]
@@ -1949,6 +1947,7 @@ name = "tnc"
 version = "1.0.0"
 dependencies = [
  "antlr-rust",
+ "approx",
  "cotengrust",
  "flexi_logger",
  "float-cmp",
@@ -1970,7 +1969,7 @@ dependencies = [
  "rustengra",
  "serde",
  "serde_json",
- "tetra",
+ "tblis",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,15 +633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,7 +1941,6 @@ dependencies = [
  "approx",
  "cotengrust",
  "flexi_logger",
- "float-cmp",
  "genetic_algorithm",
  "hdf5-metno",
  "itertools 0.14.0",

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cx q[1], q[2];
     let data = statevector.tensor_data().clone().into_data();
 
     // Print the data
-    println!("Resulting statevector is: {:?}", data.elements());
+    println!("Resulting statevector is: {:?}", data);
 }
 ```
 

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -29,7 +29,7 @@ use rand::{Rng, RngCore, SeedableRng};
 use results::{OptimizationResult, RunResult, Writer};
 use tnc::contractionpath::communication_schemes::CommunicationScheme;
 use tnc::contractionpath::contraction_cost::{
-    communication_path_cost, compute_memory_requirements, contract_size_tensors_exact,
+    communication_path_cost, compute_memory_requirements, contract_size_tensors_bytes,
 };
 use tnc::contractionpath::contraction_tree::balancing::{
     balance_partitions_iter, BalanceSettings, BalancingScheme,
@@ -257,7 +257,7 @@ fn serial_cost(tensor: &Tensor, file: &str) -> (f64, f64) {
     let memory = compute_memory_requirements(
         tensor.tensors(),
         &opt.get_best_replace_path(),
-        contract_size_tensors_exact,
+        contract_size_tensors_bytes,
     );
     last_values.replace((file.into(), (cost, memory)));
     (cost, memory)
@@ -298,7 +298,7 @@ fn do_sweep(
     let memory = compute_memory_requirements(
         partitioned_tensor.tensors(),
         &contraction_path,
-        contract_size_tensors_exact,
+        contract_size_tensors_bytes,
     );
 
     // Store the partitioning and contraction path

--- a/tnc/Cargo.toml
+++ b/tnc/Cargo.toml
@@ -21,7 +21,6 @@ itertools = "0.14.0"
 num-complex = { version = "0.4.6", features = ["serde"] }
 rand = "0.9.2"
 antlr-rust = "0.3.0-beta"
-float-cmp = "0.10.0"
 kahypar = { git = "https://github.com/Ectras/rust-kahypar" }
 permutation = "0.4.1"
 serde = { version = "1.0.218", features = ["derive"] }

--- a/tnc/Cargo.toml
+++ b/tnc/Cargo.toml
@@ -18,11 +18,10 @@ cotengra = ["dep:rustengra"]
 mpi = { version = "0.8.1", features = ["complex", "derive"] }
 hdf5-metno = { version = "0.12.4", features = ["complex"] }
 itertools = "0.14.0"
-num-complex = "0.4.6"
+num-complex = { version = "0.4.6", features = ["serde"] }
 rand = "0.9.2"
 antlr-rust = "0.3.0-beta"
 float-cmp = "0.10.0"
-tetra = { git = "https://github.com/Ectras/tetra.git", features = ["serde"] }
 kahypar = { git = "https://github.com/Ectras/rust-kahypar" }
 permutation = "0.4.1"
 serde = { version = "1.0.218", features = ["derive"] }
@@ -30,12 +29,14 @@ postcard = { version = "1.1.3", default-features = false, features = ["use-std"]
 log = { version = "0.4.22", features = ["kv_std", "kv_serde"] }
 rustc-hash = "2.1.1"
 serde_json = "1.0.133"
-ndarray = "0.17.1"
+ndarray = { version = "0.17.2", features = ["serde", "approx"] }
 genetic_algorithm = { git = "https://github.com/Ectras/genetic-algorithm.git", branch = "f64_score" }
 rayon = "1.11.0"
 ordered-float = "5.1.0"
 rustengra = { git = "https://github.com/Ectras/rustengra.git", optional = true }
 cotengrust = { git = "https://github.com/Ectras/cotengrust.git", branch = "rust_extension" }
+approx = { version = "0.5.1", features = ["num-complex"] }
+tblis = { git = "https://github.com/Ectras/rust-tblis.git" }
 
 [dev-dependencies]
 mpi-test = { git = "https://github.com/Ectras/mpi-test.git" }

--- a/tnc/examples/local_contraction.rs
+++ b/tnc/examples/local_contraction.rs
@@ -15,12 +15,14 @@ fn main() {
     let code = "\
 OPENQASM 2.0;
 include \"qelib1.inc\";
-
-qreg q[3];
-h q[0];
-cx q[0], q[1];
-cx q[1], q[2];
+qreg q[2];
+creg c[1];
+u2(0,0) q[0];
+u2(-pi,-pi) q[1];
+cx q[0],q[1];
+u2(-pi,-pi) q[0];
 ";
+    // let code = include_str!("/work/ga87com/MQTBench_2025-04-10-21-41-01/dj_indep_qiskit_10.qasm");
 
     // Create a Circuit instance out of the code
     let circuit = import_qasm(code);
@@ -46,5 +48,10 @@ cx q[1], q[2];
     let data = statevector.tensor_data().clone().into_data();
 
     // Print the data
-    println!("Resulting statevector is: {:?}", data.elements());
+    // println!("Resulting statevector is: {:?}", data.flatten());
+    for (i, amp) in data.flatten().iter().enumerate() {
+        if amp.norm() > 1e-6 {
+            println!("|{:02b}>: {:.4}", i, amp.norm_sqr());
+        }
+    }
 }

--- a/tnc/src/builders/circuit_builder.rs
+++ b/tnc/src/builders/circuit_builder.rs
@@ -6,9 +6,12 @@ use itertools::Itertools;
 use num_complex::Complex64;
 use permutation::Permutation;
 
-use crate::tensornetwork::{
-    tensor::{EdgeIndex, Tensor},
-    tensordata::TensorData,
+use crate::{
+    tensornetwork::{
+        tensor::{EdgeIndex, Tensor},
+        tensordata::TensorData,
+    },
+    utils::traits::PermutationToVec,
 };
 
 /// A quantum register, i.e., an array of qubits. Similar to the Qiskit / QASM
@@ -103,7 +106,7 @@ impl Permutor {
         // Permute legs, shape and data
         perm.apply_slice_in_place(&mut legs);
         perm.apply_slice_in_place(&mut bond_dims);
-        data = data.transpose(&perm);
+        data = data.permuted_axes(perm.to_vec());
 
         Tensor {
             tensors: vec![],
@@ -461,5 +464,24 @@ mod tests {
             vec![Complex64::new(1.0, 0.0), Complex64::new(3.0, 0.0)],
         ));
         assert_approx_eq!(&Tensor, &result, &tn_ref);
+    }
+
+    #[test]
+    fn permute() {
+        let mut tensor = Tensor::new_from_const(vec![0, 1, 2], 2);
+        let data = (0..8).map(|i| Complex64::new(i as f64, 0.0)).collect();
+        tensor.set_tensor_data(TensorData::new_from_data(&[2, 2, 2], data));
+
+        let permutor = Permutor::new(vec![2, 0, 1]);
+        let permuted = permutor.apply(tensor);
+
+        let ref_data = [0, 2, 4, 6, 1, 3, 5, 7]
+            .into_iter()
+            .map(|i| Complex64::new(i as f64, 0.0))
+            .collect();
+        let mut expected = Tensor::new_from_const(vec![2, 0, 1], 2);
+        expected.set_tensor_data(TensorData::new_from_data(&[2, 2, 2], ref_data));
+
+        assert_approx_eq!(&Tensor, &permuted, &expected);
     }
 }

--- a/tnc/src/builders/circuit_builder.rs
+++ b/tnc/src/builders/circuit_builder.rs
@@ -344,7 +344,7 @@ mod tests {
 
     use std::f64::consts::{FRAC_1_SQRT_2, FRAC_PI_3, FRAC_PI_4};
 
-    use float_cmp::assert_approx_eq;
+    use approx::assert_abs_diff_eq;
     use num_complex::Complex64;
 
     use crate::{
@@ -395,7 +395,7 @@ mod tests {
             vec![Complex64::new(FRAC_1_SQRT_2.powi(qubits as i32), 0.0)],
         ));
 
-        assert_approx_eq!(&Tensor, &result, &tn_ref);
+        assert_abs_diff_eq!(&result, &tn_ref);
     }
 
     #[test]
@@ -425,7 +425,7 @@ mod tests {
             vec![Complex64::new(FRAC_1_SQRT_2 * 0.5, 0.0)],
         ));
 
-        assert_approx_eq!(&Tensor, &result, &tn_ref);
+        assert_abs_diff_eq!(&result, &tn_ref);
     }
 
     #[test]
@@ -463,7 +463,7 @@ mod tests {
             &[2],
             vec![Complex64::new(1.0, 0.0), Complex64::new(3.0, 0.0)],
         ));
-        assert_approx_eq!(&Tensor, &result, &tn_ref);
+        assert_abs_diff_eq!(&result, &tn_ref);
     }
 
     #[test]
@@ -482,6 +482,6 @@ mod tests {
         let mut expected = Tensor::new_from_const(vec![2, 0, 1], 2);
         expected.set_tensor_data(TensorData::new_from_data(&[2, 2, 2], ref_data));
 
-        assert_approx_eq!(&Tensor, &permuted, &expected);
+        assert_abs_diff_eq!(&permuted, &expected);
     }
 }

--- a/tnc/src/builders/tensorgeneration.rs
+++ b/tnc/src/builders/tensorgeneration.rs
@@ -1,10 +1,10 @@
 use itertools::Itertools;
+use ndarray::Dim;
 use num_complex::Complex64;
 use rand::distr::Uniform;
 use rand::Rng;
-use tetra::Tensor as DataTensor;
 
-use crate::tensornetwork::tensordata::TensorData;
+use crate::tensornetwork::tensordata::{DataTensor, TensorData};
 
 /// Generates random sparse [`DataTensor`] object.
 /// Fills in sparse tensor based on `sparsity` value (defaults to `0.5`).
@@ -35,17 +35,18 @@ where
         .map(|i| Uniform::new(0, *i).unwrap())
         .collect_vec();
     let size = dims.iter().product::<usize>();
-    let mut tensor = DataTensor::new(dims);
+    let mut tensor = DataTensor::zeros(dims);
 
     let mut nnz = 0;
-    let mut loc = Vec::new();
     while (nnz as f32 / size as f32) < sparsity {
-        for r in &ranges {
-            loc.push(rng.sample(r));
-        }
+        let loc = ranges.iter().map(|r| rng.sample(r)).collect_vec();
         let val = Complex64::new(rng.random(), rng.random());
-        tensor.set(&loc, val);
-        loc.clear();
+        let dim = Dim(loc);
+        let elem = tensor.get_mut(dim).unwrap();
+        if *elem != Complex64::ZERO {
+            continue; // Skip if the location is already non-zero
+        }
+        *elem = val;
         nnz += 1;
     }
 
@@ -64,4 +65,26 @@ where
 #[must_use]
 pub fn random_sparse_tensor_data(shape: &[usize], sparsity: Option<f32>) -> TensorData {
     random_sparse_tensor_data_with_rng(shape, sparsity, &mut rand::rng())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_random_sparse_tensor_data() {
+        let shape = vec![5, 4, 3];
+        let sparsity = 0.3;
+        let tensor_data = random_sparse_tensor_data(&shape, Some(sparsity));
+        let TensorData::Matrix(tensor) = tensor_data else {
+            panic!("Expected TensorData::Matrix variant");
+        };
+        let total_elements = shape.iter().product::<usize>();
+        let non_zero_elements = tensor.iter().filter(|&&x| x != Complex64::ZERO).count();
+        let actual_sparsity = non_zero_elements as f32 / total_elements as f32;
+        assert!(
+            actual_sparsity >= sparsity,
+            "Expected sparsity around {sparsity}, but got {actual_sparsity}",
+        );
+    }
 }

--- a/tnc/src/contractionpath/candidates.rs
+++ b/tnc/src/contractionpath/candidates.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use float_cmp::approx_eq;
+use approx::abs_diff_eq;
 
 /// Struct to store contraction candidate information when searching for optimal
 /// contraction path.
@@ -14,8 +14,8 @@ pub(crate) struct Candidate {
 
 impl PartialEq for Candidate {
     fn eq(&self, other: &Self) -> bool {
-        approx_eq!(f64, self.flop_cost, other.flop_cost)
-            && approx_eq!(f64, self.size_cost, other.size_cost)
+        abs_diff_eq!(&self.flop_cost, &other.flop_cost)
+            && abs_diff_eq!(&self.size_cost, &other.size_cost)
             && self.parent_ids == other.parent_ids
             && self.child_id == other.child_id
     }

--- a/tnc/src/contractionpath/contraction_cost.rs
+++ b/tnc/src/contractionpath/contraction_cost.rs
@@ -5,7 +5,7 @@ use num_complex::Complex64;
 
 use crate::{
     contractionpath::{ContractionPath, SimplePathRef},
-    tensornetwork::tensor::{EdgeIndex, Tensor},
+    tensornetwork::tensor::Tensor,
 };
 
 /// Returns Schroedinger contraction time complexity of contracting two [`Tensor`]
@@ -73,66 +73,24 @@ pub fn contract_size_tensors(t_1: &Tensor, t_2: &Tensor) -> f64 {
     diff.size() + t_1.size() + t_2.size()
 }
 
-/// Returns a rather exact estimate of the memory requirements for
-/// contracting tensors `i` and `j`.
-///
-/// This takes into account if tensors need to be transposed (which doubles the
-/// required memory). It does not include memory of additional data like shape,
-/// bonddims, legs, etc..
+/// Returns contraction space complexity in bytes of contracting two [`Tensor`]
+/// objects.
 ///
 /// # Examples
 /// ```
 /// # use tnc::tensornetwork::tensor::Tensor;
-/// # use tnc::contractionpath::contraction_cost::contract_size_tensors_exact;
+/// # use tnc::contractionpath::contraction_cost::contract_size_tensors_bytes;
 /// # use rustc_hash::FxHashMap;
-/// let bond_dims = FxHashMap::from_iter([(0, 5),(1, 7), (2, 9), (3, 11)]);
-/// let tensor1 = Tensor::new_from_map(vec![0, 1, 2], &bond_dims); // requires 5040 bytes
-/// let tensor2 = Tensor::new_from_map(vec![3, 2], &bond_dims);    // requires 1584 bytes
-/// // result = [0, 1, 3], requires 6160 bytes
+/// let bond_dims = FxHashMap::from_iter([(0, 5),(1, 7), (2, 9), (3, 11), (4, 13)]);
+/// let tensor1 = Tensor::new_from_map(vec![0, 1, 2], &bond_dims); // 315 entries
+/// let tensor2 = Tensor::new_from_map(vec![2, 3, 4], &bond_dims); // 1287 entries
+/// // result = [0, 1, 3, 4] //  5005 entries -> total 6607 entries
 /// let tn = Tensor::new_composite(vec![tensor1, tensor2]);
-/// assert_eq!(contract_size_tensors_exact(&tn.tensor(0), &tn.tensor(1)), 12784.);
+/// assert_eq!(contract_size_tensors_bytes(&tn.tensor(0), &tn.tensor(1)), 6607. * 16.);
 /// ```
-pub fn contract_size_tensors_exact(i: &Tensor, j: &Tensor) -> f64 {
-    /// Checks if `prefix` is a prefix of `list`.
-    #[inline]
-    fn is_prefix(prefix: &[EdgeIndex], list: &[EdgeIndex]) -> bool {
-        if prefix.len() > list.len() {
-            return false;
-        }
-        list.iter().zip(prefix.iter()).all(|(a, b)| a == b)
-    }
-
-    /// Checks if `suffix` is a suffix of `list`.
-    #[inline]
-    fn is_suffix(suffix: &[EdgeIndex], list: &[EdgeIndex]) -> bool {
-        if suffix.len() > list.len() {
-            return false;
-        }
-        list.iter()
-            .rev()
-            .zip(suffix.iter().rev())
-            .all(|(a, b)| a == b)
-    }
-
-    let ij = i ^ j;
-    let contracted_legs = i & j;
-    let i_needs_transpose = !is_suffix(contracted_legs.legs(), i.legs());
-    let j_needs_transpose = !is_prefix(contracted_legs.legs(), j.legs());
-
-    let i_size = i.size();
-    let j_size = j.size();
-    let ij_size = ij.size();
-
-    let elements = match (i_needs_transpose, j_needs_transpose) {
-        (true, true) => (2.0 * i_size + j_size)
-            .max(i_size + 2.0 * j_size)
-            .max(i_size + j_size + ij_size),
-        (true, false) => (2.0 * i_size + j_size).max(i_size + j_size + ij_size),
-        (false, true) => (i_size + 2.0 * j_size).max(i_size + j_size + ij_size),
-        (false, false) => i_size + j_size + ij_size,
-    };
-
-    elements * std::mem::size_of::<Complex64>() as f64
+#[inline]
+pub fn contract_size_tensors_bytes(i: &Tensor, j: &Tensor) -> f64 {
+    contract_size_tensors(i, j) * std::mem::size_of::<Complex64>() as f64
 }
 
 /// Returns Schroedinger contraction time and space complexity of fully contracting
@@ -291,7 +249,7 @@ fn communication_path_custom_cost(
 ///
 /// Candidates for `memory_estimator` are e.g.:
 /// - [`contract_size_tensors`]
-/// - [`contract_size_tensors_exact`]
+/// - [`contract_size_tensors_bytes`]
 #[inline]
 pub fn compute_memory_requirements(
     inputs: &[Tensor],

--- a/tnc/src/contractionpath/repartitioning/genetic.rs
+++ b/tnc/src/contractionpath/repartitioning/genetic.rs
@@ -14,7 +14,7 @@ use rand::rngs::StdRng;
 use crate::{
     contractionpath::{
         communication_schemes::CommunicationScheme,
-        contraction_cost::{compute_memory_requirements, contract_size_tensors_exact},
+        contraction_cost::{compute_memory_requirements, contract_size_tensors_bytes},
         repartitioning::compute_solution,
     },
     tensornetwork::tensor::Tensor,
@@ -37,7 +37,7 @@ impl PartitioningFitness<'_> {
         let mem = compute_memory_requirements(
             partitioned_tn.tensors(),
             &path,
-            contract_size_tensors_exact,
+            contract_size_tensors_bytes,
         );
 
         // If the memory limit is exceeded, return infinity

--- a/tnc/src/contractionpath/repartitioning/simulated_annealing.rs
+++ b/tnc/src/contractionpath/repartitioning/simulated_annealing.rs
@@ -593,16 +593,16 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use approx::assert_abs_diff_eq;
 
-    use float_cmp::assert_approx_eq;
+    use super::*;
 
     #[test]
     fn simple_linear_interpolation() {
-        assert_approx_eq!(f64, linear_interpolation(0., 6., 0.5), 3.0);
-        assert_approx_eq!(f64, linear_interpolation(-1.0, 4.0, 0.2), 0.0);
-        assert_approx_eq!(f64, linear_interpolation(-7.0, -6.0, 0.0), -7.0);
-        assert_approx_eq!(f64, linear_interpolation(3.0, 5.0, 1.0), 5.0);
+        assert_abs_diff_eq!(linear_interpolation(0., 6., 0.5), 3.0);
+        assert_abs_diff_eq!(linear_interpolation(-1.0, 4.0, 0.2), 0.0);
+        assert_abs_diff_eq!(linear_interpolation(-7.0, -6.0, 0.0), -7.0);
+        assert_abs_diff_eq!(linear_interpolation(3.0, 5.0, 1.0), 5.0);
     }
 
     #[test]

--- a/tnc/src/contractionpath/repartitioning/simulated_annealing.rs
+++ b/tnc/src/contractionpath/repartitioning/simulated_annealing.rs
@@ -14,7 +14,7 @@ use rustc_hash::FxHashSet;
 use crate::{
     contractionpath::{
         communication_schemes::CommunicationScheme,
-        contraction_cost::{compute_memory_requirements, contract_size_tensors_exact},
+        contraction_cost::{compute_memory_requirements, contract_size_tensors_bytes},
         paths::{
             cotengrust::{Cotengrust, OptMethod},
             FindPath,
@@ -185,7 +185,7 @@ where
         let mem = compute_memory_requirements(
             partitioned_tn.tensors(),
             &path,
-            contract_size_tensors_exact,
+            contract_size_tensors_bytes,
         );
 
         if mem > limit {

--- a/tnc/src/gates.rs
+++ b/tnc/src/gates.rs
@@ -8,10 +8,11 @@ use std::{
 };
 
 use itertools::Itertools;
+use ndarray::array;
 use num_complex::Complex64;
-use permutation::Permutation;
 use rustc_hash::FxHashSet;
-use tetra::Tensor as DataTensor;
+
+use crate::{tensornetwork::tensordata::DataTensor, utils::traits::ConjugateInPlace};
 
 static GATES: LazyLock<RwLock<FxHashSet<Box<dyn Gate>>>> = LazyLock::new(|| {
     let mut gates = FxHashSet::default();
@@ -84,7 +85,8 @@ fn matrix_transpose_inplace(data: &mut DataTensor) {
         assert!(data.ndim().is_power_of_two());
         let half = data.ndim() / 2;
         let perm = (half..data.ndim()).chain(0..half).collect_vec();
-        *data = data.transpose(&Permutation::oneline(perm));
+        let used_data = std::mem::take(data);
+        *data = used_data.permuted_axes(perm);
     }
 }
 
@@ -155,12 +157,7 @@ impl Gate for X {
         let [] = unpack_angles(angles);
         let z = Complex64::ZERO;
         let o = Complex64::ONE;
-        #[rustfmt::skip]
-        let data = vec![
-            z, o,
-            o, z,
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![[z, o], [o, z],].into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -180,12 +177,7 @@ impl Gate for Y {
         let [] = unpack_angles(angles);
         let z = Complex64::ZERO;
         let i = Complex64::I;
-        #[rustfmt::skip]
-        let data = vec![
-            z, -i,
-            i,  z,
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![[z, -i], [i, z]].into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -205,12 +197,7 @@ impl Gate for Z {
         let [] = unpack_angles(angles);
         let z = Complex64::ZERO;
         let o = Complex64::ONE;
-        #[rustfmt::skip]
-        let data = vec![
-            o,  z,
-            z, -o,
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![[o, z], [z, -o]].into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -229,12 +216,7 @@ impl Gate for H {
     fn compute(&self, angles: &[f64]) -> DataTensor {
         let [] = unpack_angles(angles);
         let h = Complex64::new(FRAC_1_SQRT_2, 0.0);
-        #[rustfmt::skip]
-        let data = vec![
-            h,  h,
-            h, -h,
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![[h, h], [h, -h]].into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -255,12 +237,7 @@ impl Gate for T {
         let z = Complex64::ZERO;
         let o = Complex64::ONE;
         let t = Complex64::new(FRAC_1_SQRT_2, FRAC_1_SQRT_2);
-        #[rustfmt::skip]
-        let data = vec![
-            o, z,
-            z, t,
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![[o, z], [z, t]].into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -281,26 +258,31 @@ impl Gate for U {
     fn compute(&self, angles: &[f64]) -> DataTensor {
         let [theta, phi, lambda] = unpack_angles(angles);
         let (sin, cos) = (theta / 2.0).sin_cos();
-        let data = vec![
-            Complex64::new(cos, 0.0),
-            -(Complex64::I * lambda).exp() * sin,
-            (Complex64::I * phi).exp() * sin,
-            (Complex64::I * (phi + lambda)).exp() * cos,
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![
+            [
+                Complex64::new(cos, 0.0),
+                -(Complex64::I * lambda).exp() * sin
+            ],
+            [
+                (Complex64::I * phi).exp() * sin,
+                (Complex64::I * (phi + lambda)).exp() * cos
+            ]
+        ]
+        .into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
         // This explicit implementation is ~30% faster
         let [theta, phi, lambda] = unpack_angles(angles);
         let (sin, cos) = (theta / 2.0).sin_cos();
-        let data = vec![
-            Complex64::new(cos, 0.0),
-            (Complex64::I * -phi).exp() * sin,
-            -(Complex64::I * -lambda).exp() * sin,
-            (Complex64::I * -(phi + lambda)).exp() * cos,
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![
+            [Complex64::new(cos, 0.0), (Complex64::I * -phi).exp() * sin],
+            [
+                -(Complex64::I * -lambda).exp() * sin,
+                (Complex64::I * -(phi + lambda)).exp() * cos
+            ]
+        ]
+        .into_dyn()
     }
 }
 
@@ -315,12 +297,7 @@ impl Gate for Sx {
         let [] = unpack_angles(angles);
         let a = Complex64::new(0.5, 0.5);
         let b = Complex64::new(0.5, -0.5);
-        #[rustfmt::skip]
-        let data = vec![
-            a, b,
-            b, a,
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![[a, b], [b, a]].into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -342,12 +319,7 @@ impl Gate for Sy {
         let [] = unpack_angles(angles);
         let a = Complex64::new(0.5, 0.5);
         let b = Complex64::new(-0.5, -0.5);
-        #[rustfmt::skip]
-        let data = vec![
-            a, b,
-            a, a,
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![[a, b], [a, a]].into_dyn()
     }
 }
 
@@ -363,12 +335,7 @@ impl Gate for Sz {
         let z = Complex64::ZERO;
         let o = Complex64::ONE;
         let i = Complex64::I;
-        #[rustfmt::skip]
-        let data = vec![
-            o, z,
-            z, i,
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![[o, z], [z, i]].into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -391,12 +358,7 @@ impl Gate for Rx {
         let (sin, cos) = (theta / 2.0).sin_cos();
         let o = Complex64::ONE;
         let i = Complex64::I;
-        #[rustfmt::skip]
-        let data = vec![
-            o*cos, -i*sin,
-            -i*sin, o*cos,
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![[o * cos, -i * sin], [-i * sin, o * cos]].into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -417,12 +379,7 @@ impl Gate for Ry {
         let (sin, cos) = (theta / 2.0).sin_cos();
         let o = Complex64::ONE;
 
-        #[rustfmt::skip]
-        let data = vec![
-            o*cos, -o*sin,
-            o*sin, o*cos,
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![[o * cos, -o * sin], [o * sin, o * cos]].into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -443,12 +400,7 @@ impl Gate for Rz {
         let z = Complex64::ZERO;
         let i = Complex64::I;
 
-        #[rustfmt::skip]
-        let data = vec![
-            (-i*theta/2.0).exp(), z,
-            z, (i*theta/2.0).exp(),
-        ];
-        DataTensor::new_from_flat(&[2, 2], data)
+        array![[(-i * theta / 2.0).exp(), z], [z, (i * theta / 2.0).exp()]].into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -468,14 +420,10 @@ impl Gate for Cx {
         let [] = unpack_angles(angles);
         let z = Complex64::ZERO;
         let o = Complex64::ONE;
-        #[rustfmt::skip]
-        let data = vec![
-            o, z, z, z,
-            z, o, z, z,
-            z, z, z, o,
-            z, z, o, z,
-        ];
-        DataTensor::new_from_flat(&[2, 2, 2, 2], data)
+        array![[o, z, z, z], [z, o, z, z], [z, z, z, o], [z, z, o, z]]
+            .into_shape_with_order((2, 2, 2, 2))
+            .unwrap()
+            .into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -495,14 +443,10 @@ impl Gate for Cz {
         let [] = unpack_angles(angles);
         let z = Complex64::ZERO;
         let o = Complex64::ONE;
-        #[rustfmt::skip]
-        let data = vec![
-            o, z, z, z,
-            z, o, z, z,
-            z, z, o, z,
-            z, z, z, -o,
-        ];
-        DataTensor::new_from_flat(&[2, 2, 2, 2], data)
+        array![[o, z, z, z], [z, o, z, z], [z, z, o, z], [z, z, z, -o]]
+            .into_shape_with_order((2, 2, 2, 2))
+            .unwrap()
+            .into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -522,14 +466,10 @@ impl Gate for Swap {
         let [] = unpack_angles(angles);
         let z = Complex64::ZERO;
         let o = Complex64::ONE;
-        #[rustfmt::skip]
-        let data = vec![
-            o, z, z, z,
-            z, z, o, z,
-            z, o, z, z,
-            z, z, z, o,
-        ];
-        DataTensor::new_from_flat(&[2, 2, 2, 2], data)
+        array![[o, z, z, z], [z, z, o, z], [z, o, z, z], [z, z, z, o]]
+            .into_shape_with_order((2, 2, 2, 2))
+            .unwrap()
+            .into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -550,14 +490,10 @@ impl Gate for Cp {
         let z = Complex64::ZERO;
         let o = Complex64::ONE;
         let e = (Complex64::I * theta).exp();
-        #[rustfmt::skip]
-        let data = vec![
-            o, z, z, z,
-            z, o, z, z,
-            z, z, o, z,
-            z, z, z, e,
-        ];
-        DataTensor::new_from_flat(&[2, 2, 2, 2], data)
+        array![[o, z, z, z], [z, o, z, z], [z, z, o, z], [z, z, z, e]]
+            .into_shape_with_order((2, 2, 2, 2))
+            .unwrap()
+            .into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -578,14 +514,10 @@ impl Gate for Iswap {
         let z = Complex64::ZERO;
         let o = Complex64::ONE;
         let i = Complex64::I;
-        #[rustfmt::skip]
-        let data = vec![
-            o, z, z, z,
-            z, z, i, z,
-            z, i, z, z,
-            z, z, z, o,
-        ];
-        DataTensor::new_from_flat(&[2, 2, 2, 2], data)
+        array![[o, z, z, z], [z, z, i, z], [z, i, z, z], [z, z, z, o]]
+            .into_shape_with_order((2, 2, 2, 2))
+            .unwrap()
+            .into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -610,14 +542,10 @@ impl Gate for Fsim {
         let a = Complex64::new(theta.cos(), 0.0);
         let b = Complex64::new(0.0, -theta.sin());
         let c = Complex64::new(0.0, -phi).exp();
-        #[rustfmt::skip]
-        let data = vec![
-            o, z, z, z,
-            z, a, b, z,
-            z, b, a, z,
-            z, z, z, c,
-        ];
-        DataTensor::new_from_flat(&[2, 2, 2, 2], data)
+        array![[o, z, z, z], [z, a, b, z], [z, b, a, z], [z, z, z, c]]
+            .into_shape_with_order((2, 2, 2, 2))
+            .unwrap()
+            .into_dyn()
     }
 
     fn adjoint(&self, angles: &[f64]) -> DataTensor {
@@ -630,7 +558,7 @@ impl Gate for Fsim {
 mod tests {
     use std::f64::consts::PI;
 
-    use float_cmp::assert_approx_eq;
+    use approx::assert_abs_diff_eq;
     use rand::{distr::Uniform, prelude::Distribution, rngs::StdRng, SeedableRng};
     use rustc_hash::FxHashMap;
 
@@ -675,7 +603,7 @@ mod tests {
             let mut matrix = gate.compute(&params);
             matrix_adjoint_inplace(&mut matrix);
             let general_adjoint = matrix;
-            assert_approx_eq!(&DataTensor, &specialized_adjoint, &general_adjoint);
+            assert_abs_diff_eq!(&specialized_adjoint, &general_adjoint);
         }
     }
 }

--- a/tnc/src/io/hdf5.rs
+++ b/tnc/src/io/hdf5.rs
@@ -103,7 +103,6 @@ mod tests {
     use std::iter::zip;
 
     use approx::assert_abs_diff_eq;
-    use float_cmp::assert_approx_eq;
     use hdf5_metno::{AttributeBuilder, File, Result};
     use ndarray::{array, Array2};
     use num_complex::Complex64;
@@ -189,8 +188,8 @@ mod tests {
             Complex64::new(0.0, 1.0),
         ];
         for (u, v) in zip(ref_data.iter(), tensor_data.flatten().iter()) {
-            assert_approx_eq!(f64, u.re, v.re, epsilon = 1e-8);
-            assert_approx_eq!(f64, u.im, v.im, epsilon = 1e-8);
+            assert_abs_diff_eq!(u.re, v.re, epsilon = 1e-8);
+            assert_abs_diff_eq!(u.im, v.im, epsilon = 1e-8);
         }
     }
 
@@ -212,7 +211,7 @@ mod tests {
         ));
         ref_tn.push_tensor(ref_tensor);
         ref_tn.set_legs(vec![0, 1]);
-        assert_approx_eq!(&Tensor, &tensor, &ref_tn);
+        assert_abs_diff_eq!(&tensor, &ref_tn);
     }
 
     #[test]

--- a/tnc/src/io/hdf5.rs
+++ b/tnc/src/io/hdf5.rs
@@ -17,12 +17,10 @@
 use std::path::Path;
 
 use hdf5_metno::{File, Result};
-use ndarray::Array;
 use num_complex::Complex64;
-use tetra::Tensor as DataTensor;
 
 use crate::tensornetwork::tensor::Tensor;
-use crate::tensornetwork::tensordata::TensorData;
+use crate::tensornetwork::tensordata::{DataTensor, TensorData};
 
 /// Loads a tensor network from a HDF5 file.
 pub fn load_tensor<P>(filename: P) -> Result<Tensor>
@@ -69,15 +67,10 @@ fn read_tensor(file: &File) -> Result<Tensor> {
         let tensor = gr.dataset(&tensor_name)?;
         let bond_ids = tensor.attr("bids").unwrap().read_1d::<usize>()?;
         let tensor_dataset = gr.dataset(&tensor_name).unwrap().read_dyn::<Complex64>()?;
-        let tensor_shape = tensor_dataset.shape().to_vec();
+        let tensor_shape = tensor_dataset.shape();
         let bond_dims = tensor_shape.iter().map(|s| *s as u64).collect();
         let mut new_tensor = Tensor::new(bond_ids.to_vec(), bond_dims);
-        let (data, offset) = tensor_dataset.into_raw_vec_and_offset();
-        assert_eq!(offset, Some(0));
-        new_tensor.set_tensor_data(TensorData::Matrix(DataTensor::new_from_flat(
-            &tensor_shape,
-            data,
-        )));
+        new_tensor.set_tensor_data(TensorData::Matrix(tensor_dataset));
         new_tensor_network.push_tensor(new_tensor);
     }
     new_tensor_network.set_legs(out_bond_ids.to_vec());
@@ -93,18 +86,12 @@ fn read_data(file: &File) -> Result<DataTensor> {
         .dataset(&tensor_name[0])
         .unwrap()
         .read_dyn::<Complex64>()?;
-    let tensor_shape = tensor_dataset.shape().to_vec();
-    let (data, offset) = tensor_dataset.into_raw_vec_and_offset();
-    assert_eq!(offset, Some(0));
-    Ok(DataTensor::new_from_flat(&tensor_shape, data))
+    Ok(tensor_dataset)
 }
 
 fn write_data(file: &File, tensor: &DataTensor) -> Result<()> {
     let gr = file.create_group("/tensors")?;
-    let data = tensor.elements().to_vec();
-    let shape = tensor.shape().to_vec();
-    let data = Array::from_shape_vec(shape, data)?;
-    let tensor_dataset = gr.new_dataset_builder().with_data(&data);
+    let tensor_dataset = gr.new_dataset_builder().with_data(tensor);
     tensor_dataset.create("-1")?;
     file.flush()
 }
@@ -115,15 +102,15 @@ mod tests {
 
     use std::iter::zip;
 
+    use approx::assert_abs_diff_eq;
     use float_cmp::assert_approx_eq;
     use hdf5_metno::{AttributeBuilder, File, Result};
-    use ndarray::array;
+    use ndarray::{array, Array2};
     use num_complex::Complex64;
     use rand::{
         distr::{Alphanumeric, SampleString},
         rng,
     };
-    use tetra::Tensor as DataTensor;
 
     use crate::tensornetwork::tensor::Tensor;
     use crate::tensornetwork::tensordata::TensorData;
@@ -148,7 +135,7 @@ mod tests {
         let attribute = attribute.with_data(&bid);
         attribute.create("bids")?;
 
-        let data = Array::from_shape_vec(
+        let data = Array2::<Complex64>::from_shape_vec(
             (2, 2),
             vec![
                 Complex64::new(1.0, 0.0),
@@ -156,7 +143,8 @@ mod tests {
                 Complex64::new(3.0, 0.0),
                 Complex64::new(0.0, 1.0),
             ],
-        )?;
+        )?
+        .into_dyn();
         let dataset_builder2 = tensor_group.new_dataset_builder();
         let dataset_data_builder2 = dataset_builder2.with_data(&data);
         let dataset2 = dataset_data_builder2.create("0")?;
@@ -173,7 +161,7 @@ mod tests {
         let new_file = new_in_memory_file()?;
         let tensor_group = new_file.create_group("./tensors")?;
         let dataset_builder = tensor_group.new_dataset_builder();
-        let data = Array::from_shape_vec(
+        let data = Array2::<Complex64>::from_shape_vec(
             (2, 2),
             vec![
                 Complex64::new(1.0, 0.0),
@@ -181,7 +169,8 @@ mod tests {
                 Complex64::new(3.0, 0.0),
                 Complex64::new(0.0, 1.0),
             ],
-        )?;
+        )?
+        .into_dyn();
         let dataset_data_builder = dataset_builder.with_data(&data);
         dataset_data_builder.create("-1")?;
         new_file.flush()?;
@@ -199,7 +188,7 @@ mod tests {
             Complex64::new(3.0, 0.0),
             Complex64::new(0.0, 1.0),
         ];
-        for (u, v) in zip(ref_data.iter(), tensor_data.elements().iter()) {
+        for (u, v) in zip(ref_data.iter(), tensor_data.flatten().iter()) {
             assert_approx_eq!(f64, u.re, v.re, epsilon = 1e-8);
             assert_approx_eq!(f64, u.im, v.im, epsilon = 1e-8);
         }
@@ -237,11 +226,13 @@ mod tests {
             Complex64::new(0.0, 0.0),
             Complex64::new(0.5, 2.0),
         ];
-        let tensor = DataTensor::new_from_flat(&[2, 3], data);
+        let tensor = Array2::<Complex64>::from_shape_vec((2, 3), data)
+            .unwrap()
+            .into_dyn();
 
         write_data(&file, &tensor).unwrap();
         let read = read_data(&file).unwrap();
 
-        assert_approx_eq!(&DataTensor, &tensor, &read);
+        assert_abs_diff_eq!(&tensor, &read);
     }
 }

--- a/tnc/src/io/qasm/ast.rs
+++ b/tnc/src/io/qasm/ast.rs
@@ -3,7 +3,7 @@ use std::{
     ops,
 };
 
-use float_cmp::approx_eq;
+use approx::abs_diff_eq;
 use itertools::join;
 
 use crate::gates::is_gate_known;
@@ -142,7 +142,7 @@ impl PartialEq for Expr {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Int(l0), Self::Int(r0)) => l0 == r0,
-            (Self::Float(l0), Self::Float(r0)) => approx_eq!(f64, *l0, *r0),
+            (Self::Float(l0), Self::Float(r0)) => abs_diff_eq!(*l0, *r0),
             (Self::Variable(l0), Self::Variable(r0)) => l0 == r0,
             (Self::Unary(l0, l1), Self::Unary(r0, r1)) => l0 == r0 && l1 == r1,
             (Self::Binary(l0, l1, l2), Self::Binary(r0, r1, r2)) => {

--- a/tnc/src/io/qasm/qasm_importer.rs
+++ b/tnc/src/io/qasm/qasm_importer.rs
@@ -43,7 +43,7 @@ mod tests {
 
     use std::f64::consts::FRAC_1_SQRT_2;
 
-    use float_cmp::assert_approx_eq;
+    use approx::assert_abs_diff_eq;
     use num_complex::Complex64;
 
     use crate::{
@@ -189,7 +189,7 @@ mod tests {
                 Complex64::new(FRAC_1_SQRT_2, 0.),
             ],
         );
-        assert_approx_eq!(&TensorData, &resulting_state, &expected);
+        assert_abs_diff_eq!(&resulting_state, &expected);
     }
 
     #[test]
@@ -218,7 +218,7 @@ mod tests {
                 Complex64::ZERO,
             ],
         );
-        assert_approx_eq!(&TensorData, &resulting_state, &expected);
+        assert_abs_diff_eq!(&resulting_state, &expected);
     }
 
     fn odd_test_circuit() -> Circuit {
@@ -253,7 +253,7 @@ mod tests {
                 Complex64::new(0.0, -0.24340376901515096),
             ],
         );
-        assert_approx_eq!(&TensorData, &resulting_state, &expected);
+        assert_abs_diff_eq!(&resulting_state, &expected);
     }
 
     #[test]
@@ -270,7 +270,7 @@ mod tests {
                 Complex64::new(-0.03678688170631573, 0.0),
             ],
         );
-        assert_approx_eq!(&TensorData, &resulting_state, &expected);
+        assert_abs_diff_eq!(&resulting_state, &expected);
     }
 
     #[test]
@@ -289,7 +289,7 @@ mod tests {
                 Complex64::new(0.0, -0.24340376901515096),
             ],
         );
-        assert_approx_eq!(&TensorData, &resulting_state, &expected);
+        assert_abs_diff_eq!(&resulting_state, &expected);
     }
 
     #[test]
@@ -317,6 +317,6 @@ mod tests {
                 Complex64::new(FRAC_1_SQRT_2, 0.0),
             ],
         );
-        assert_approx_eq!(&TensorData, &resulting_state, &expected);
+        assert_abs_diff_eq!(&resulting_state, &expected);
     }
 }

--- a/tnc/src/mpi/serialization.rs
+++ b/tnc/src/mpi/serialization.rs
@@ -82,7 +82,7 @@ pub fn deserialize_tensor(data: &[MessageBinaryBlob]) -> Tensor {
 mod tests {
     use super::*;
 
-    use float_cmp::assert_approx_eq;
+    use approx::assert_abs_diff_eq;
     use num_complex::Complex64;
     use rustc_hash::FxHashMap;
 
@@ -97,7 +97,7 @@ mod tests {
         let ta = Tensor::new_composite(vec![t2, t3, t4]);
         let serialized = serialize_tensor(&ta);
         let deserialized = deserialize_tensor(&serialized);
-        assert_approx_eq!(&Tensor, &ta, &deserialized);
+        assert_abs_diff_eq!(&ta, &deserialized);
     }
 
     #[test]
@@ -108,6 +108,6 @@ mod tests {
         tensor.set_tensor_data(TensorData::new_from_data(&[2, 3], data));
         let serialized = serialize_tensor(&tensor);
         let deserialized = deserialize_tensor(&serialized);
-        assert_approx_eq!(&Tensor, &tensor, &deserialized);
+        assert_abs_diff_eq!(&tensor, &deserialized);
     }
 }

--- a/tnc/src/tensornetwork/contraction.rs
+++ b/tnc/src/tensornetwork/contraction.rs
@@ -1,10 +1,14 @@
 //! Functionality to contract tensor networks.
 use log::debug;
-use tetra::contract;
+use ndarray::Axis;
+use tblis::{tensor_mult, TensorView};
 
 use crate::{
     contractionpath::ContractionPath,
-    tensornetwork::{tensor::Tensor, tensordata::TensorData},
+    tensornetwork::{
+        tensor::Tensor,
+        tensordata::{DataTensor, TensorData},
+    },
 };
 
 /// Fully contracts `tn` based on the given `contract_path` using ReplaceLeft format.
@@ -75,7 +79,7 @@ impl TensorContraction for Tensor {
             ..
         } = tensor_b;
 
-        let result = contract(
+        let result = contract_ndarrays(
             &tensor_symmetric_difference.legs,
             &a_legs,
             a_data.into_data(),
@@ -86,6 +90,36 @@ impl TensorContraction for Tensor {
         tensor_symmetric_difference.set_tensor_data(TensorData::Matrix(result));
         self.tensors[tensor_a_loc] = tensor_symmetric_difference;
     }
+}
+
+fn contract_ndarrays(
+    out_labels: &[usize],
+    a_labels: &[usize],
+    a_data: DataTensor,
+    b_labels: &[usize],
+    b_data: DataTensor,
+) -> DataTensor {
+    assert_eq!(a_labels.len(), a_data.ndim());
+    assert_eq!(b_labels.len(), b_data.ndim());
+
+    // Find output shape
+    let mut out_shape = Vec::with_capacity(out_labels.len());
+    for label in out_labels {
+        if let Some(a_index) = a_labels.iter().position(|l| l == label) {
+            out_shape.push(a_data.len_of(Axis(a_index)));
+        } else if let Some(b_index) = b_labels.iter().position(|l| l == label) {
+            out_shape.push(b_data.len_of(Axis(b_index)));
+        } else {
+            panic!("Out label {label} not found in input a ({a_labels:?}) or b ({b_labels:?})");
+        }
+    }
+
+    // Contract with TBLIS
+    let a_view = TensorView::new(a_labels, a_data.shape(), a_data.strides(), a_data.as_ptr());
+    let b_view = TensorView::new(b_labels, b_data.shape(), b_data.strides(), b_data.as_ptr());
+    let out_data = tensor_mult(out_labels, &out_shape, a_view, b_view);
+
+    DataTensor::from_shape_vec(out_shape, out_data).unwrap()
 }
 
 #[cfg(test)]

--- a/tnc/src/tensornetwork/contraction.rs
+++ b/tnc/src/tensornetwork/contraction.rs
@@ -126,7 +126,7 @@ fn contract_ndarrays(
 mod tests {
     use super::*;
 
-    use float_cmp::assert_approx_eq;
+    use approx::assert_abs_diff_eq;
     use num_complex::Complex64;
     use rustc_hash::FxHashMap;
     use serde::Deserialize;
@@ -183,12 +183,12 @@ mod tests {
         let mut tn_12 = Tensor::new_composite(vec![t1.clone(), t2.clone(), t3.clone()]);
 
         tn_12.contract_tensors(0, 1);
-        assert_approx_eq!(&Tensor, tn_12.tensor(0), &t12, epsilon = 1e-14);
+        assert_abs_diff_eq!(tn_12.tensor(0), &t12, epsilon = 1e-14);
 
         let mut tn_23 = Tensor::new_composite(vec![t1, t2, t3]);
 
         tn_23.contract_tensors(1, 2);
-        assert_approx_eq!(&Tensor, tn_23.tensor(1), &t23, epsilon = 1e-14);
+        assert_abs_diff_eq!(tn_23.tensor(1), &t23, epsilon = 1e-14);
     }
 
     #[test]
@@ -218,7 +218,7 @@ mod tests {
         let contract_path = path![(0, 1), (0, 2)];
 
         let result = contract_tensor_network(tn, &contract_path);
-        assert_approx_eq!(&Tensor, &result, &tout, epsilon = 1e-14);
+        assert_abs_diff_eq!(result, &tout, epsilon = 1e-14);
     }
 
     #[test]
@@ -255,7 +255,7 @@ mod tests {
         ));
 
         let result = contract_tensor_network(t3, &contract_path);
-        assert_approx_eq!(&Tensor, &result, &tn_ref);
+        assert_abs_diff_eq!(result, &tn_ref);
     }
 
     #[test]
@@ -287,6 +287,6 @@ mod tests {
         ));
 
         let result = contract_tensor_network(tn, &contract_path);
-        assert_approx_eq!(&Tensor, &result, &tn_ref);
+        assert_abs_diff_eq!(result, &tn_ref);
     }
 }

--- a/tnc/src/tensornetwork/partitioning.rs
+++ b/tnc/src/tensornetwork/partitioning.rs
@@ -178,7 +178,7 @@ pub fn partition_tensor_network(tn: Tensor, partitioning: &[usize]) -> Tensor {
 mod tests {
     use super::*;
 
-    use float_cmp::assert_approx_eq;
+    use approx::assert_abs_diff_eq;
     use rustc_hash::FxHashMap;
 
     use crate::tensornetwork::partitioning::partition_config::PartitioningStrategy;
@@ -232,9 +232,9 @@ mod tests {
         let partitioned_tn = partition_tensor_network(tn, partitioning.as_slice());
         assert_eq!(partitioned_tn.tensors().len(), 3);
 
-        assert_approx_eq!(&Tensor, partitioned_tn.tensor(2), &ref_tensor_1);
-        assert_approx_eq!(&Tensor, partitioned_tn.tensor(1), &ref_tensor_2);
-        assert_approx_eq!(&Tensor, partitioned_tn.tensor(0), &ref_tensor_3);
+        assert_abs_diff_eq!(partitioned_tn.tensor(2), &ref_tensor_1);
+        assert_abs_diff_eq!(partitioned_tn.tensor(1), &ref_tensor_2);
+        assert_abs_diff_eq!(partitioned_tn.tensor(0), &ref_tensor_3);
     }
 
     #[test]

--- a/tnc/src/tensornetwork/tensor.rs
+++ b/tnc/src/tensornetwork/tensor.rs
@@ -2,7 +2,7 @@ use std::iter::zip;
 use std::num::TryFromIntError;
 use std::ops::{BitAnd, BitOr, BitXor, BitXorAssign, Sub};
 
-use float_cmp::{ApproxEq, F64Margin};
+use approx::AbsDiffEq;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
@@ -498,11 +498,23 @@ impl Tensor {
     }
 }
 
-impl ApproxEq for &Tensor {
-    type Margin = F64Margin;
+impl PartialEq for Tensor {
+    fn eq(&self, other: &Self) -> bool {
+        self.legs == other.legs
+            && self.bond_dims == other.bond_dims
+            && self.tensors == other.tensors
+            && self.tensordata == other.tensordata
+    }
+}
 
-    fn approx_eq<M: Into<Self::Margin>>(self, other: Self, margin: M) -> bool {
-        let margin = margin.into();
+impl AbsDiffEq for Tensor {
+    type Epsilon = f64;
+
+    fn default_epsilon() -> Self::Epsilon {
+        f64::default_epsilon()
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
         if self.legs != other.legs {
             return false;
         }
@@ -513,12 +525,12 @@ impl ApproxEq for &Tensor {
             return false;
         }
         for (tensor, other_tensor) in zip(&self.tensors, &other.tensors) {
-            if !tensor.approx_eq(other_tensor, margin) {
+            if !Tensor::abs_diff_eq(tensor, other_tensor, epsilon) {
                 return false;
             }
         }
 
-        self.tensordata.approx_eq(&other.tensordata, margin)
+        TensorData::abs_diff_eq(&self.tensordata, &other.tensordata, epsilon)
     }
 }
 
@@ -567,7 +579,7 @@ mod tests {
 
     use std::iter::zip;
 
-    use float_cmp::assert_approx_eq;
+    use approx::assert_abs_diff_eq;
     use rustc_hash::FxHashMap;
 
     use crate::tensornetwork::tensordata::TensorData;
@@ -644,7 +656,7 @@ mod tests {
         let external = tensor_1234.external_tensor();
 
         let ref_tensor = Tensor::new_from_map(vec![4, 5, 7, 9], &bond_dims);
-        assert_approx_eq!(&Tensor, &external, &ref_tensor);
+        assert_abs_diff_eq!(&external, &ref_tensor);
     }
 
     #[test]
@@ -661,7 +673,7 @@ mod tests {
         tensor.push_tensor(tensor_1);
 
         for (sub_tensor, ref_tensor) in zip(tensor.tensors(), [&ref_tensor_1]) {
-            assert_approx_eq!(&Tensor, sub_tensor, ref_tensor);
+            assert_abs_diff_eq!(sub_tensor, ref_tensor);
         }
 
         // Push tensor 2
@@ -669,7 +681,7 @@ mod tests {
         tensor.push_tensor(tensor_2);
 
         for (sub_tensor, ref_tensor) in zip(tensor.tensors(), [&ref_tensor_1, &ref_tensor_2]) {
-            assert_approx_eq!(&Tensor, sub_tensor, ref_tensor);
+            assert_abs_diff_eq!(sub_tensor, ref_tensor);
         }
 
         // Test that other fields are unchanged
@@ -707,7 +719,7 @@ mod tests {
             tensor.tensors(),
             &vec![ref_tensor_1, ref_tensor_2, ref_tensor_3],
         ) {
-            assert_approx_eq!(&Tensor, sub_tensor, ref_tensor);
+            assert_abs_diff_eq!(sub_tensor, ref_tensor);
         }
     }
 

--- a/tnc/src/tensornetwork/tensordata.rs
+++ b/tnc/src/tensornetwork/tensordata.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
-use approx::ulps_eq;
-use float_cmp::{ApproxEq, F64Margin};
+use approx::AbsDiffEq;
 use ndarray::ArrayD;
 use num_complex::Complex64;
 use serde::{Deserialize, Serialize};
@@ -14,7 +13,7 @@ use crate::{
 pub type DataTensor = ArrayD<Complex64>;
 
 /// The data of a tensor.
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TensorData {
     /// This is for composite tensors that have not been contracted yet, as well as
     /// empty tensors in general.
@@ -71,24 +70,29 @@ impl TensorData {
     }
 }
 
-impl ApproxEq for &TensorData {
-    type Margin = F64Margin;
+impl AbsDiffEq for TensorData {
+    type Epsilon = f64;
 
-    fn approx_eq<M: Into<Self::Margin>>(self, other: Self, margin: M) -> bool {
-        let margin = margin.into();
+    fn default_epsilon() -> Self::Epsilon {
+        f64::EPSILON
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
         match (self, other) {
             (TensorData::File(l0), TensorData::File(r0)) => l0 == r0,
             (
                 TensorData::Gate((name_l, angles_l, adjoint_l)),
                 TensorData::Gate((name_r, angles_r, adjoint_r)),
-            ) => name_l == name_r && adjoint_l == adjoint_r && angles_l.approx_eq(angles_r, margin),
+            ) => {
+                name_l == name_r
+                    && adjoint_l == adjoint_r
+                    && angles_l
+                        .iter()
+                        .zip(angles_r)
+                        .all(|(l, r)| f64::abs_diff_eq(l, r, epsilon))
+            }
             (TensorData::Matrix(l0), TensorData::Matrix(r0)) => {
-                ulps_eq!(
-                    l0,
-                    r0,
-                    max_ulps = margin.ulps as _,
-                    epsilon = margin.epsilon
-                )
+                DataTensor::abs_diff_eq(l0, r0, epsilon)
             }
             (TensorData::Uncontracted, TensorData::Uncontracted) => true,
             _ => false,
@@ -98,39 +102,39 @@ impl ApproxEq for &TensorData {
 
 #[cfg(test)]
 mod tests {
-    use float_cmp::assert_approx_eq;
+    use approx::assert_abs_diff_eq;
 
     use super::*;
 
     #[test]
-    #[should_panic(expected = "assertion failed: `(left approx_eq right)`")]
+    #[should_panic(expected = "assert_abs_diff_eq!")]
     fn gates_eq_different_name() {
         let g1 = TensorData::Gate((String::from("cx"), vec![], false));
         let g2 = TensorData::Gate((String::from("CX"), vec![], false));
-        assert_approx_eq!(&TensorData, &g1, &g2);
+        assert_abs_diff_eq!(&g1, &g2);
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: `(left approx_eq right)`")]
+    #[should_panic(expected = "assert_abs_diff_eq!")]
     fn gates_eq_adjoint() {
         let g1 = TensorData::Gate((String::from("h"), vec![], false));
         let g2 = TensorData::Gate((String::from("h"), vec![], true));
-        assert_approx_eq!(&TensorData, &g1, &g2);
+        assert_abs_diff_eq!(&g1, &g2);
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: `(left approx_eq right)`")]
+    #[should_panic(expected = "assert_abs_diff_eq!")]
     fn gates_eq_different_angles() {
         let g1 = TensorData::Gate((String::from("u"), vec![1.4, 2.0, -3.0], false));
         let g2 = TensorData::Gate((String::from("u"), vec![1.4, -2.0, -3.0], false));
-        assert_approx_eq!(&TensorData, &g1, &g2);
+        assert_abs_diff_eq!(&g1, &g2);
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: `(left approx_eq right)`")]
+    #[should_panic(expected = "assert_abs_diff_eq!")]
     fn eq_different_data() {
         let g1 = TensorData::Gate((String::from("u"), vec![1.4, 2.0, -3.0], false));
         let g2 = TensorData::new_from_data(&[], vec![Complex64::ONE]);
-        assert_approx_eq!(&TensorData, &g1, &g2);
+        assert_abs_diff_eq!(&g1, &g2);
     }
 }

--- a/tnc/src/tensornetwork/tensordata.rs
+++ b/tnc/src/tensornetwork/tensordata.rs
@@ -1,14 +1,17 @@
 use std::path::PathBuf;
 
+use approx::ulps_eq;
 use float_cmp::{ApproxEq, F64Margin};
+use ndarray::ArrayD;
 use num_complex::Complex64;
 use serde::{Deserialize, Serialize};
-use tetra::Tensor as DataTensor;
 
 use crate::{
     gates::{load_gate, load_gate_adjoint, matrix_adjoint_inplace},
     io::hdf5::load_data,
 };
+
+pub type DataTensor = ArrayD<Complex64>;
 
 /// The data of a tensor.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
@@ -29,7 +32,7 @@ impl TensorData {
     /// Creates a new tensor from raw (flat) data.
     #[must_use]
     pub fn new_from_data(dimensions: &[usize], data: Vec<Complex64>) -> Self {
-        Self::Matrix(DataTensor::new_from_flat(dimensions, data))
+        Self::Matrix(ArrayD::from_shape_vec(dimensions, data).unwrap())
     }
 
     /// Consumes the tensor data and returns the contained tensor.
@@ -79,7 +82,14 @@ impl ApproxEq for &TensorData {
                 TensorData::Gate((name_l, angles_l, adjoint_l)),
                 TensorData::Gate((name_r, angles_r, adjoint_r)),
             ) => name_l == name_r && adjoint_l == adjoint_r && angles_l.approx_eq(angles_r, margin),
-            (TensorData::Matrix(l0), TensorData::Matrix(r0)) => l0.approx_eq(r0, margin),
+            (TensorData::Matrix(l0), TensorData::Matrix(r0)) => {
+                ulps_eq!(
+                    l0,
+                    r0,
+                    max_ulps = margin.ulps as _,
+                    epsilon = margin.epsilon
+                )
+            }
             (TensorData::Uncontracted, TensorData::Uncontracted) => true,
             _ => false,
         }

--- a/tnc/src/utils/traits.rs
+++ b/tnc/src/utils/traits.rs
@@ -5,6 +5,9 @@ use std::{
     hash::{BuildHasher, Hash},
 };
 
+use ndarray::ArrayD;
+use num_complex::Complex64;
+use permutation::Permutation;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
 /// Trait for inserting a new key-value pair into a map.
@@ -49,6 +52,31 @@ impl<K, V> WithCapacity for FxHashMap<K, V> {
     }
 }
 
+/// Extension trait for Permutation to get a `Vec<usize>` usable for permuting axes
+/// of an ndarray.
+pub trait PermutationToVec {
+    fn to_vec(&self) -> Vec<usize>;
+}
+
+impl PermutationToVec for Permutation {
+    #[inline]
+    fn to_vec(&self) -> Vec<usize> {
+        (0..self.len()).map(|i| self.apply_inv_idx(i)).collect()
+    }
+}
+
+/// Extension trait for ArrayD to compute the conjugate in-place.
+pub trait ConjugateInPlace {
+    fn conjugate(&mut self);
+}
+
+impl ConjugateInPlace for ArrayD<Complex64> {
+    #[inline]
+    fn conjugate(&mut self) {
+        self.map_inplace(|x| *x = x.conj());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,5 +105,19 @@ mod tests {
     fn test_with_capacity() {
         let hm = FxHashMap::<char, usize>::with_capacity(10);
         assert!(hm.capacity() >= 10);
+    }
+
+    #[test]
+    fn test_permutation_to_vec() {
+        // Permutation:
+        // 0 -> 2
+        // 1 -> 0
+        // 2 -> 1
+        let perm = Permutation::oneline(vec![2, 0, 1]);
+        // ndarray uses the convention that out[i] = in[perm[i]], e.g. if
+        // in = [a, b, c], then out should be [b, c, a].
+        // perm as vec should then be [1, 2, 0].
+
+        assert_eq!(perm.to_vec(), vec![1, 2, 0]);
     }
 }

--- a/tnc/tests/integration_tests.rs
+++ b/tnc/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-use float_cmp::assert_approx_eq;
+use approx::assert_abs_diff_eq;
 use mpi::traits::Communicator;
 use mpi_test::mpi_test;
 use rand::{rngs::StdRng, SeedableRng};
@@ -14,8 +14,6 @@ use tnc::{
     tensornetwork::{
         contraction::contract_tensor_network,
         partitioning::{find_partitioning, partition_tensor_network, PartitioningStrategy},
-        tensor::Tensor,
-        tensordata::TensorData,
     },
 };
 
@@ -37,7 +35,7 @@ fn test_partitioned_contraction_random() {
     opt.find_path();
     let path = opt.get_best_replace_path();
     let result = contract_tensor_network(partitioned_tn, &path);
-    assert_approx_eq!(&Tensor, &ref_result, &result);
+    assert_abs_diff_eq!(&result, &ref_result);
 }
 
 #[test]
@@ -58,7 +56,7 @@ fn test_partitioned_contraction() {
     opt.find_path();
     let path = opt.get_best_replace_path();
     let result = contract_tensor_network(partitioned_tn, &path);
-    assert_approx_eq!(&Tensor, &ref_result, &result);
+    assert_abs_diff_eq!(&result, &ref_result);
 }
 
 #[test]
@@ -79,7 +77,7 @@ fn test_partitioned_contraction_mixed() {
     opt.find_path();
     let path = opt.get_best_replace_path();
     let result = contract_tensor_network(partitioned_tn, &path);
-    assert_approx_eq!(&Tensor, &ref_result, &result);
+    assert_abs_diff_eq!(&result, &ref_result);
 }
 
 #[mpi_test(2)]
@@ -159,6 +157,6 @@ fn test_partitioned_contraction_need_mpi() {
 
         let ref_tn = contract_tensor_network(ref_tn, &ref_path);
 
-        assert_approx_eq!(&TensorData, local_tn.tensor_data(), ref_tn.tensor_data());
+        assert_abs_diff_eq!(&local_tn.tensor_data(), &ref_tn.tensor_data());
     }
 }


### PR DESCRIPTION
Since moving from MKL to tblis made the contraction simpler, tetra
didn't comprise so much complexity anymore, becoming somewhat
superfluous. ndarray is maintained, equally efficient, and can handle
arbitrary slicing, which was on the TODO list for tetra.

Depends on #94.