### PR TITLE
Pathfinder API rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use TBLIS instead of HPTT + MKL for contraction. This means contractions are faster and often require only half as much memory. Also, build time decreased.
 - Use ndarray instead of own implementation for tensors. This means more features (slicing, arbitrary memory layout, ...) and interoperability.
 - Implement `approx` instead of `float-cmp` for tensors and tensor data
+- `find_path` now takes the tensor network as argument and returns a results struct
 
 ### Removed
 - Function `contract_size_tensors_exact` (since there is no explicit transpose, the normal contraction size estimate is sufficient)
+- Functions `get_best_path`, `get_best_flops`, ... from `FindPath` trait. They exist on the struct returned by `find_path` now
 
 ## [1.0.1] - 2026-05-26
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ cx q[1], q[2];
 
     // Find a contraction path to contract the tensor network.
     // We use a greedy path finder here.
-    let mut opt = Cotengrust::new(&tensor_network, OptMethod::Greedy);
-    let result = opt.find_path();
+    let mut opt = Cotengrust::new(OptMethod::Greedy);
+    let result = opt.find_path(&tensor_network);
     let path = result.replace_path();
 
     // Contract the tensor network locally

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Local contractions on a single system are also possible.
 use tnc::{
     contractionpath::paths::{
         cotengrust::{Cotengrust, OptMethod},
-        FindPath,
+        ContractionPathResult, Pathfinder,
     },
     io::qasm::import_qasm,
     tensornetwork::contraction::contract_tensor_network,
@@ -57,8 +57,8 @@ cx q[1], q[2];
     // Find a contraction path to contract the tensor network.
     // We use a greedy path finder here.
     let mut opt = Cotengrust::new(&tensor_network, OptMethod::Greedy);
-    opt.find_path();
-    let path = opt.get_best_replace_path();
+    let result = opt.find_path();
+    let path = result.replace_path();
 
     // Contract the tensor network locally
     let final_tensor = contract_tensor_network(tensor_network, &path);

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -251,8 +251,8 @@ fn serial_cost(tensor: &Tensor, file: &str) -> (f64, f64) {
             return *out;
         }
     }
-    let mut opt = Cotengrust::new(tensor, OptMethod::Greedy);
-    let result = opt.find_path();
+    let mut opt = Cotengrust::new(OptMethod::Greedy);
+    let result = opt.find_path(tensor);
     let cost = result.flops();
     let memory = compute_memory_requirements(
         tensor.tensors(),
@@ -755,8 +755,8 @@ impl MethodRun for CotengraTempering {
         rng: &mut StdRng,
     ) -> (Tensor, ContractionPath, f64, f64) {
         let seed = rng.next_u64();
-        let mut tree = TreeTempering::new(tensor, Some(seed), CostType::Flops, Some(300));
-        let result = tree.find_path();
+        let mut tree = TreeTempering::new(Some(seed), CostType::Flops, Some(300));
+        let result = tree.find_path(tensor);
         let best_path = result.replace_path();
         let best_path_simple = best_path.clone().into_simple();
 
@@ -790,9 +790,8 @@ impl MethodRun for CotengraAnneal {
         rng: &mut StdRng,
     ) -> (Tensor, ContractionPath, f64, f64) {
         let seed = rng.next_u64();
-        let mut tree =
-            TreeAnnealing::new(tensor, Some(seed), CostType::Flops, Some(300), Some(100));
-        let result = tree.find_path();
+        let mut tree = TreeAnnealing::new(Some(seed), CostType::Flops, Some(300), Some(100));
+        let result = tree.find_path(tensor);
         let best_path = result.replace_path();
         let best_path_simple = best_path.clone().into_simple();
 
@@ -825,13 +824,12 @@ impl MethodRun for CotengraHyper {
         _rng: &mut StdRng,
     ) -> (Tensor, ContractionPath, f64, f64) {
         let mut tree = Hyperoptimizer::new(
-            tensor,
             CostType::Flops,
             HyperOptions::new()
                 .with_max_time(&TIME_LIMIT)
                 .with_max_repeats(100_000),
         );
-        let result = tree.find_path();
+        let result = tree.find_path(tensor);
         let best_path = result.replace_path();
         let best_path_simple = best_path.clone().into_simple();
 

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -38,7 +38,7 @@ use tnc::contractionpath::paths::cotengrust::{Cotengrust, OptMethod};
 use tnc::contractionpath::paths::hyperoptimization::{HyperOptions, Hyperoptimizer};
 use tnc::contractionpath::paths::tree_annealing::TreeAnnealing;
 use tnc::contractionpath::paths::tree_tempering::TreeTempering;
-use tnc::contractionpath::paths::{CostType, FindPath};
+use tnc::contractionpath::paths::{ContractionPathResult, CostType, Pathfinder};
 use tnc::contractionpath::repartitioning::simulated_annealing::{
     IntermediatePartitioningModel, LeafPartitioningModel, NaiveIntermediatePartitioningModel,
     NaivePartitioningModel,
@@ -252,11 +252,11 @@ fn serial_cost(tensor: &Tensor, file: &str) -> (f64, f64) {
         }
     }
     let mut opt = Cotengrust::new(tensor, OptMethod::Greedy);
-    opt.find_path();
-    let cost = opt.get_best_flops();
+    let result = opt.find_path();
+    let cost = result.flops();
     let memory = compute_memory_requirements(
         tensor.tensors(),
-        &opt.get_best_replace_path(),
+        &result.replace_path(),
         contract_size_tensors_bytes,
     );
     last_values.replace((file.into(), (cost, memory)));
@@ -756,8 +756,8 @@ impl MethodRun for CotengraTempering {
     ) -> (Tensor, ContractionPath, f64, f64) {
         let seed = rng.next_u64();
         let mut tree = TreeTempering::new(tensor, Some(seed), CostType::Flops, Some(300));
-        tree.find_path();
-        let best_path = tree.get_best_replace_path();
+        let result = tree.find_path();
+        let best_path = result.replace_path();
         let best_path_simple = best_path.clone().into_simple();
 
         let (parallel_flops, _) =
@@ -792,8 +792,8 @@ impl MethodRun for CotengraAnneal {
         let seed = rng.next_u64();
         let mut tree =
             TreeAnnealing::new(tensor, Some(seed), CostType::Flops, Some(300), Some(100));
-        tree.find_path();
-        let best_path = tree.get_best_replace_path();
+        let result = tree.find_path();
+        let best_path = result.replace_path();
         let best_path_simple = best_path.clone().into_simple();
 
         let (parallel_flops, _) =
@@ -831,8 +831,8 @@ impl MethodRun for CotengraHyper {
                 .with_max_time(&TIME_LIMIT)
                 .with_max_repeats(100_000),
         );
-        tree.find_path();
-        let best_path = tree.get_best_replace_path();
+        let result = tree.find_path();
+        let best_path = result.replace_path();
         let best_path_simple = best_path.clone().into_simple();
 
         let (parallel_flops, _) =

--- a/tnc/examples/distributed_contraction.rs
+++ b/tnc/examples/distributed_contraction.rs
@@ -51,8 +51,8 @@ fn distributed_contraction(tensor: Tensor, world: &SimpleCommunicator) -> Tensor
         let partitioned_tn = partition_tensor_network(tensor, &partitioning);
 
         // Find a contraction path for the individual partitions and the final fan-in
-        let mut opt = Cotengrust::new(&partitioned_tn, OptMethod::Greedy);
-        let result = opt.find_path();
+        let mut opt = Cotengrust::new(OptMethod::Greedy);
+        let result = opt.find_path(&partitioned_tn);
         let path = result.replace_path();
 
         (partitioned_tn, path)

--- a/tnc/examples/distributed_contraction.rs
+++ b/tnc/examples/distributed_contraction.rs
@@ -4,7 +4,7 @@ use tnc::{
     builders::sycamore_circuit::sycamore_circuit,
     contractionpath::paths::{
         cotengrust::{Cotengrust, OptMethod},
-        FindPath,
+        ContractionPathResult, Pathfinder,
     },
     mpi::communication::{
         broadcast_path, intermediate_reduce_tensor_network, scatter_tensor_network,
@@ -52,8 +52,8 @@ fn distributed_contraction(tensor: Tensor, world: &SimpleCommunicator) -> Tensor
 
         // Find a contraction path for the individual partitions and the final fan-in
         let mut opt = Cotengrust::new(&partitioned_tn, OptMethod::Greedy);
-        opt.find_path();
-        let path = opt.get_best_replace_path();
+        let result = opt.find_path();
+        let path = result.replace_path();
 
         (partitioned_tn, path)
     } else {

--- a/tnc/examples/local_contraction.rs
+++ b/tnc/examples/local_contraction.rs
@@ -4,7 +4,7 @@
 use tnc::{
     contractionpath::paths::{
         cotengrust::{Cotengrust, OptMethod},
-        FindPath,
+        ContractionPathResult, Pathfinder,
     },
     io::qasm::import_qasm,
     tensornetwork::contraction::contract_tensor_network,
@@ -33,8 +33,8 @@ fn main() {
     // Find a contraction path to contract the tensor network.
     // We use a greedy path finder here.
     let mut opt = Cotengrust::new(&tensor_network, OptMethod::Greedy);
-    opt.find_path();
-    let path = opt.get_best_replace_path();
+    let result = opt.find_path();
+    let path = result.replace_path();
 
     // Contract the tensor network locally
     let final_tensor = contract_tensor_network(tensor_network, &path);

--- a/tnc/examples/local_contraction.rs
+++ b/tnc/examples/local_contraction.rs
@@ -32,8 +32,8 @@ fn main() {
 
     // Find a contraction path to contract the tensor network.
     // We use a greedy path finder here.
-    let mut opt = Cotengrust::new(&tensor_network, OptMethod::Greedy);
-    let result = opt.find_path();
+    let mut opt = Cotengrust::new(OptMethod::Greedy);
+    let result = opt.find_path(&tensor_network);
     let path = result.replace_path();
 
     // Contract the tensor network locally

--- a/tnc/examples/repartitioning.rs
+++ b/tnc/examples/repartitioning.rs
@@ -8,7 +8,7 @@ use tnc::{
         contraction_cost::{communication_path_cost, contract_path_cost},
         paths::{
             cotengrust::{Cotengrust, OptMethod},
-            FindPath,
+            ContractionPathResult, Pathfinder,
         },
         repartitioning::simulated_annealing::{self, IntermediatePartitioningModel},
     },
@@ -24,8 +24,8 @@ fn compute_cost(tensor: &Tensor, partitioning: &[usize]) -> f64 {
 
     // Find a contraction path
     let mut opt = Cotengrust::new(&partitioned_tn, OptMethod::Greedy);
-    opt.find_path();
-    let path = opt.get_best_replace_path();
+    let result = opt.find_path();
+    let path = result.replace_path();
 
     // Get the serial contraction cost of each partition
     let cost_per_partition = partitioned_tn

--- a/tnc/examples/repartitioning.rs
+++ b/tnc/examples/repartitioning.rs
@@ -23,8 +23,8 @@ fn compute_cost(tensor: &Tensor, partitioning: &[usize]) -> f64 {
     let partitioned_tn = partition_tensor_network(tensor.clone(), partitioning);
 
     // Find a contraction path
-    let mut opt = Cotengrust::new(&partitioned_tn, OptMethod::Greedy);
-    let result = opt.find_path();
+    let mut opt = Cotengrust::new(OptMethod::Greedy);
+    let result = opt.find_path(&partitioned_tn);
     let path = result.replace_path();
 
     // Get the serial contraction cost of each partition

--- a/tnc/src/builders/circuit_builder.rs
+++ b/tnc/src/builders/circuit_builder.rs
@@ -350,7 +350,7 @@ mod tests {
     use crate::{
         contractionpath::paths::{
             cotengrust::{Cotengrust, OptMethod},
-            FindPath,
+            ContractionPathResult, Pathfinder,
         },
         path,
         tensornetwork::{
@@ -384,8 +384,8 @@ mod tests {
         assert!(permutor.is_identity());
 
         let mut opt = Cotengrust::new(&tensor_network, OptMethod::Greedy);
-        opt.find_path();
-        let path = opt.get_best_replace_path();
+        let result = opt.find_path();
+        let path = result.replace_path();
 
         let result = contract_tensor_network(tensor_network, &path);
 
@@ -414,8 +414,8 @@ mod tests {
         let tensor_network = circuit.into_expectation_value_network();
 
         let mut opt = Cotengrust::new(&tensor_network, OptMethod::Greedy);
-        opt.find_path();
-        let path = opt.get_best_replace_path();
+        let result = opt.find_path();
+        let path = result.replace_path();
 
         let result = contract_tensor_network(tensor_network, &path);
 

--- a/tnc/src/builders/circuit_builder.rs
+++ b/tnc/src/builders/circuit_builder.rs
@@ -383,8 +383,8 @@ mod tests {
         let (tensor_network, permutor) = circuit.into_amplitude_network("00000");
         assert!(permutor.is_identity());
 
-        let mut opt = Cotengrust::new(&tensor_network, OptMethod::Greedy);
-        let result = opt.find_path();
+        let mut opt = Cotengrust::new(OptMethod::Greedy);
+        let result = opt.find_path(&tensor_network);
         let path = result.replace_path();
 
         let result = contract_tensor_network(tensor_network, &path);
@@ -413,8 +413,8 @@ mod tests {
         );
         let tensor_network = circuit.into_expectation_value_network();
 
-        let mut opt = Cotengrust::new(&tensor_network, OptMethod::Greedy);
-        let result = opt.find_path();
+        let mut opt = Cotengrust::new(OptMethod::Greedy);
+        let result = opt.find_path(&tensor_network);
         let path = result.replace_path();
 
         let result = contract_tensor_network(tensor_network, &path);

--- a/tnc/src/contractionpath/communication_schemes.rs
+++ b/tnc/src/contractionpath/communication_schemes.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashMap;
 use crate::contractionpath::contraction_cost::communication_path_cost;
 use crate::contractionpath::paths::cotengrust::{Cotengrust, OptMethod};
 use crate::contractionpath::paths::weighted_branchbound::WeightedBranchBound;
-use crate::contractionpath::paths::{CostType, FindPath};
+use crate::contractionpath::paths::{ContractionPathResult, CostType, Pathfinder};
 use crate::contractionpath::SimplePath;
 use crate::tensornetwork::partitioning::{communication_partitioning, PartitioningStrategy};
 use crate::tensornetwork::tensor::Tensor;
@@ -75,8 +75,8 @@ impl CommunicationScheme {
 fn greedy(children_tensors: &[Tensor], _latency_map: &FxHashMap<usize, f64>) -> SimplePath {
     let communication_tensors = Tensor::new_composite(children_tensors.to_vec());
     let mut opt = Cotengrust::new(&communication_tensors, OptMethod::Greedy);
-    opt.find_path();
-    opt.get_best_replace_path().into_simple()
+    let result = opt.find_path();
+    result.replace_path().into_simple()
 }
 
 fn bipartition(children_tensors: &[Tensor], _latency_map: &FxHashMap<usize, f64>) -> SimplePath {
@@ -132,8 +132,8 @@ fn weighted_branchbound(
         latency_map.clone(),
         CostType::Flops,
     );
-    opt.find_path();
-    opt.get_best_replace_path().into_simple()
+    let result = opt.find_path();
+    result.replace_path().into_simple()
 }
 
 fn branchbound(children_tensors: &[Tensor]) -> SimplePath {
@@ -147,8 +147,8 @@ fn branchbound(children_tensors: &[Tensor]) -> SimplePath {
         latency_map,
         CostType::Flops,
     );
-    opt.find_path();
-    opt.get_best_replace_path().into_simple()
+    let result = opt.find_path();
+    result.replace_path().into_simple()
 }
 
 /// Uses recursive bipartitioning to identify a communication scheme for final tensors
@@ -224,8 +224,8 @@ fn random_greedy(children_tensors: &[Tensor]) -> SimplePath {
     let communication_tensors = Tensor::new_composite(children_tensors.to_vec());
 
     let mut opt = Cotengrust::new(&communication_tensors, OptMethod::RandomGreedy(100));
-    opt.find_path();
-    opt.get_best_replace_path().into_simple()
+    let result = opt.find_path();
+    result.replace_path().into_simple()
 }
 
 #[cfg(test)]

--- a/tnc/src/contractionpath/communication_schemes.rs
+++ b/tnc/src/contractionpath/communication_schemes.rs
@@ -74,8 +74,8 @@ impl CommunicationScheme {
 
 fn greedy(children_tensors: &[Tensor], _latency_map: &FxHashMap<usize, f64>) -> SimplePath {
     let communication_tensors = Tensor::new_composite(children_tensors.to_vec());
-    let mut opt = Cotengrust::new(&communication_tensors, OptMethod::Greedy);
-    let result = opt.find_path();
+    let mut opt = Cotengrust::new(OptMethod::Greedy);
+    let result = opt.find_path(&communication_tensors);
     result.replace_path().into_simple()
 }
 
@@ -125,14 +125,8 @@ fn weighted_branchbound(
 ) -> SimplePath {
     let communication_tensors = Tensor::new_composite(children_tensors.to_vec());
 
-    let mut opt = WeightedBranchBound::new(
-        &communication_tensors,
-        Some(10),
-        5.,
-        latency_map.clone(),
-        CostType::Flops,
-    );
-    let result = opt.find_path();
+    let mut opt = WeightedBranchBound::new(Some(10), 5., latency_map.clone(), CostType::Flops);
+    let result = opt.find_path(&communication_tensors);
     result.replace_path().into_simple()
 }
 
@@ -140,14 +134,8 @@ fn branchbound(children_tensors: &[Tensor]) -> SimplePath {
     let communication_tensors = Tensor::new_composite(children_tensors.to_vec());
     let latency_map = (0..children_tensors.len()).map(|i| (i, 0.0)).collect();
 
-    let mut opt = WeightedBranchBound::new(
-        &communication_tensors,
-        Some(10),
-        5.,
-        latency_map,
-        CostType::Flops,
-    );
-    let result = opt.find_path();
+    let mut opt = WeightedBranchBound::new(Some(10), 5., latency_map, CostType::Flops);
+    let result = opt.find_path(&communication_tensors);
     result.replace_path().into_simple()
 }
 
@@ -223,8 +211,8 @@ fn tensor_bipartition(children_tensor: &[(usize, Tensor)], imbalance: f64) -> Si
 fn random_greedy(children_tensors: &[Tensor]) -> SimplePath {
     let communication_tensors = Tensor::new_composite(children_tensors.to_vec());
 
-    let mut opt = Cotengrust::new(&communication_tensors, OptMethod::RandomGreedy(100));
-    let result = opt.find_path();
+    let mut opt = Cotengrust::new(OptMethod::RandomGreedy(100));
+    let result = opt.find_path(&communication_tensors);
     result.replace_path().into_simple()
 }
 

--- a/tnc/src/contractionpath/contraction_tree/utils.rs
+++ b/tnc/src/contractionpath/contraction_tree/utils.rs
@@ -7,7 +7,7 @@ use crate::{
         contraction_tree::{balancing::PartitionData, ContractionTree},
         paths::{
             cotengrust::{Cotengrust, OptMethod},
-            FindPath,
+            ContractionPathResult, Pathfinder,
         },
         ContractionPath, SimplePath,
     },
@@ -68,9 +68,9 @@ pub(super) fn subtree_contraction_path(
     let subtree_tensor_network = Tensor::new_composite(tensors);
 
     let mut opt = Cotengrust::new(&subtree_tensor_network, OptMethod::Greedy);
-    opt.find_path();
+    let result = opt.find_path();
 
-    let smaller_path_new_index = opt.get_best_replace_path();
+    let smaller_path_new_index = result.replace_path();
     let smaller_path_new_index = smaller_path_new_index.into_simple();
 
     let smaller_path_node_index = smaller_path_new_index
@@ -81,8 +81,8 @@ pub(super) fn subtree_contraction_path(
     (
         smaller_path_node_index,
         smaller_path_new_index,
-        opt.get_best_flops(),
-        opt.get_best_size(),
+        result.flops(),
+        result.size(),
     )
 }
 

--- a/tnc/src/contractionpath/contraction_tree/utils.rs
+++ b/tnc/src/contractionpath/contraction_tree/utils.rs
@@ -67,8 +67,8 @@ pub(super) fn subtree_contraction_path(
     // Obtain tensor network corresponding to subtree
     let subtree_tensor_network = Tensor::new_composite(tensors);
 
-    let mut opt = Cotengrust::new(&subtree_tensor_network, OptMethod::Greedy);
-    let result = opt.find_path();
+    let mut opt = Cotengrust::new(OptMethod::Greedy);
+    let result = opt.find_path(&subtree_tensor_network);
 
     let smaller_path_new_index = result.replace_path();
     let smaller_path_new_index = smaller_path_new_index.into_simple();

--- a/tnc/src/contractionpath/paths.rs
+++ b/tnc/src/contractionpath/paths.rs
@@ -1,6 +1,6 @@
 //! Contraction path finders.
 
-use crate::contractionpath::ContractionPath;
+use crate::contractionpath::{ssa_replace_ordering, ContractionPath};
 
 pub mod branchbound;
 pub mod cotengrust;
@@ -15,21 +15,59 @@ pub mod tree_tempering;
 pub mod weighted_branchbound;
 
 /// An optimizer for finding a contraction path.
-pub trait FindPath {
-    /// Finds a contraction path.
-    fn find_path(&mut self);
+pub trait Pathfinder {
+    type Result: ContractionPathResult;
 
+    /// Finds a contraction path.
+    fn find_path(&mut self) -> Self::Result;
+}
+
+/// The result of running a contraction [`Pathfinder`].
+pub trait ContractionPathResult {
     /// Returns the best found contraction path in SSA format.
-    fn get_best_path(&self) -> &ContractionPath;
+    fn ssa_path(&self) -> &ContractionPath;
 
     /// Returns the best found contraction path in ReplaceLeft format.
-    fn get_best_replace_path(&self) -> ContractionPath;
+    fn replace_path(&self) -> ContractionPath;
 
     /// Returns the total op count of the best path found.
-    fn get_best_flops(&self) -> f64;
+    fn flops(&self) -> f64;
 
     /// Returns the max memory (in number of elements) of the best path found.
-    fn get_best_size(&self) -> f64;
+    fn size(&self) -> f64;
+}
+
+/// Basic result data from running a contraction [`Pathfinder`].
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct BasicContractionPathResult {
+    /// The found path in SSA format.
+    ssa_path: ContractionPath,
+    /// The computational cost of the found path.
+    flops: f64,
+    /// The peak memory of the found path.
+    size: f64,
+}
+
+impl ContractionPathResult for BasicContractionPathResult {
+    #[inline]
+    fn ssa_path(&self) -> &ContractionPath {
+        &self.ssa_path
+    }
+
+    #[inline]
+    fn replace_path(&self) -> ContractionPath {
+        ssa_replace_ordering(&self.ssa_path)
+    }
+
+    #[inline]
+    fn flops(&self) -> f64 {
+        self.flops
+    }
+
+    #[inline]
+    fn size(&self) -> f64 {
+        self.size
+    }
 }
 
 /// The cost metric to optimize for.

--- a/tnc/src/contractionpath/paths.rs
+++ b/tnc/src/contractionpath/paths.rs
@@ -1,6 +1,9 @@
 //! Contraction path finders.
 
-use crate::contractionpath::{ssa_replace_ordering, ContractionPath};
+use crate::{
+    contractionpath::{ssa_replace_ordering, ContractionPath},
+    tensornetwork::tensor::Tensor,
+};
 
 pub mod branchbound;
 pub mod cotengrust;
@@ -18,8 +21,10 @@ pub mod weighted_branchbound;
 pub trait Pathfinder {
     type Result: ContractionPathResult;
 
-    /// Finds a contraction path.
-    fn find_path(&mut self) -> Self::Result;
+    /// Finds a contraction path for the `tensor`.
+    ///
+    /// Uses `&mut self` to allow for internal state such as caching.
+    fn find_path(&mut self, tensor: &Tensor) -> Self::Result;
 }
 
 /// The result of running a contraction [`Pathfinder`].

--- a/tnc/src/contractionpath/paths/branchbound.rs
+++ b/tnc/src/contractionpath/paths/branchbound.rs
@@ -7,8 +7,8 @@ use crate::{
     contractionpath::{
         candidates::Candidate,
         contraction_cost::{contract_cost_tensors, contract_size_tensors},
-        paths::{CostType, FindPath},
-        ssa_ordering, ssa_replace_ordering, ContractionPath,
+        paths::{BasicContractionPathResult, ContractionPathResult, CostType, Pathfinder},
+        ssa_ordering, ContractionPath,
     },
     tensornetwork::tensor::Tensor,
     utils::traits::HashMapInsertNew,
@@ -174,10 +174,12 @@ impl<'a> BranchBound<'a> {
     }
 }
 
-impl FindPath for BranchBound<'_> {
-    fn find_path(&mut self) {
+impl Pathfinder for BranchBound<'_> {
+    type Result = BasicContractionPathResult;
+
+    fn find_path(&mut self) -> BasicContractionPathResult {
         if self.tn.is_leaf() {
-            return;
+            return BasicContractionPathResult::default();
         }
         let tensors = self.tn.tensors().clone();
         self.flop_cache.clear();
@@ -195,8 +197,8 @@ impl FindPath for BranchBound<'_> {
                     self.cutoff_flops_factor,
                     self.minimize,
                 );
-                bb.find_path();
-                nested_paths.insert(index, bb.get_best_path().clone());
+                let result = bb.find_path();
+                nested_paths.insert(index, result.ssa_path().clone());
                 tensor = tensor.external_tensor();
             }
             self.size_cache
@@ -207,26 +209,15 @@ impl FindPath for BranchBound<'_> {
         }
         let remaining = (0..self.tn.tensors().len()).collect_vec();
         self.branch_iterate(&[], &remaining, 0f64, 0f64);
-        self.best_path = ContractionPath {
+        let best_path = ContractionPath {
             nested: nested_paths,
             toplevel: std::mem::take(&mut self.best_path).into_simple(),
         };
-    }
-
-    fn get_best_flops(&self) -> f64 {
-        self.best_flops
-    }
-
-    fn get_best_size(&self) -> f64 {
-        self.best_size
-    }
-
-    fn get_best_path(&self) -> &ContractionPath {
-        &self.best_path
-    }
-
-    fn get_best_replace_path(&self) -> ContractionPath {
-        ssa_replace_ordering(&self.best_path)
+        BasicContractionPathResult {
+            ssa_path: best_path,
+            flops: self.best_flops,
+            size: self.best_size,
+        }
     }
 }
 
@@ -236,7 +227,7 @@ mod tests {
 
     use rustc_hash::FxHashMap;
 
-    use crate::contractionpath::paths::{CostType, FindPath};
+    use crate::contractionpath::paths::{CostType, Pathfinder};
     use crate::path;
     use crate::tensornetwork::tensor::Tensor;
 
@@ -279,26 +270,31 @@ mod tests {
     fn test_contract_order_simple() {
         let tn = setup_simple();
         let mut opt = BranchBound::new(&tn, None, 20., CostType::Flops);
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.best_flops, 4540.);
-        assert_eq!(opt.best_size, 538.);
-        assert_eq!(opt.get_best_path(), &path![(1, 0), (2, 3)]);
-        assert_eq!(opt.get_best_replace_path(), path![(1, 0), (2, 1)]);
+        assert_eq!(
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(1, 0), (2, 3)],
+                flops: 4540.,
+                size: 538.
+            }
+        );
     }
 
     #[test]
     fn test_contract_order_complex() {
         let tn = setup_complex();
         let mut opt = BranchBound::new(&tn, None, 20., CostType::Flops);
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.best_flops, 2654474.);
-        assert_eq!(opt.best_size, 89478.);
-        assert_eq!(opt.best_path, path![(1, 5), (0, 6), (2, 7), (3, 8), (4, 9)]);
         assert_eq!(
-            opt.get_best_replace_path(),
-            path![(1, 5), (0, 1), (2, 0), (3, 2), (4, 3)]
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(1, 5), (0, 6), (2, 7), (3, 8), (4, 9)],
+                flops: 2654474.,
+                size: 89478.
+            }
         );
     }
 }

--- a/tnc/src/contractionpath/paths/branchbound.rs
+++ b/tnc/src/contractionpath/paths/branchbound.rs
@@ -14,9 +14,8 @@ use crate::{
     utils::traits::HashMapInsertNew,
 };
 
-/// A struct with an [`FindPath`] implementation that explores possible pair contractions in a depth-first manner.
-pub struct BranchBound<'a> {
-    tn: &'a Tensor,
+/// A struct with an [`Pathfinder`] implementation that explores possible pair contractions in a depth-first manner.
+pub struct BranchBound {
     nbranch: Option<usize>,
     cutoff_flops_factor: f64,
     minimize: CostType,
@@ -30,15 +29,9 @@ pub struct BranchBound<'a> {
     tensor_cache: FxHashMap<usize, Tensor>,
 }
 
-impl<'a> BranchBound<'a> {
-    pub fn new(
-        tn: &'a Tensor,
-        nbranch: Option<usize>,
-        cutoff_flops_factor: f64,
-        minimize: CostType,
-    ) -> Self {
+impl BranchBound {
+    pub fn new(nbranch: Option<usize>, cutoff_flops_factor: f64, minimize: CostType) -> Self {
         Self {
-            tn,
             nbranch,
             cutoff_flops_factor,
             minimize,
@@ -118,6 +111,7 @@ impl<'a> BranchBound<'a> {
     /// the Python based `opt_einsum` implementation. Found at <https://github.com/dgasmith/opt_einsum>.
     fn branch_iterate(
         &mut self,
+        tensor: &Tensor,
         path: &[(usize, usize, usize)],
         remaining: &[usize],
         flops: f64,
@@ -129,14 +123,14 @@ impl<'a> BranchBound<'a> {
                     if self.best_flops > flops {
                         self.best_flops = flops;
                         self.best_size = size;
-                        self.best_path = ssa_ordering(path, self.tn.tensors().len());
+                        self.best_path = ssa_ordering(path, tensor.tensors().len());
                     }
                 }
                 CostType::Size => {
                     if self.best_size > size {
                         self.best_flops = flops;
                         self.best_size = size;
-                        self.best_path = ssa_ordering(path, self.tn.tensors().len());
+                        self.best_path = ssa_ordering(path, tensor.tensors().len());
                     }
                 }
             }
@@ -169,19 +163,19 @@ impl<'a> BranchBound<'a> {
             new_remaining.push(child_id);
             new_path = path.to_vec();
             new_path.push((parent_ids.0, parent_ids.1, child_id));
-            self.branch_iterate(&new_path, &new_remaining, flop_cost, size_cost);
+            self.branch_iterate(tensor, &new_path, &new_remaining, flop_cost, size_cost);
         }
     }
 }
 
-impl Pathfinder for BranchBound<'_> {
+impl Pathfinder for BranchBound {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self) -> BasicContractionPathResult {
-        if self.tn.is_leaf() {
+    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
+        if tensor.is_leaf() {
             return BasicContractionPathResult::default();
         }
-        let tensors = self.tn.tensors().clone();
+        let tensors = tensor.tensors().clone();
         self.flop_cache.clear();
         self.size_cache.clear();
         self.result_cache.clear();
@@ -191,13 +185,9 @@ impl Pathfinder for BranchBound<'_> {
         for (index, mut tensor) in tensors.into_iter().enumerate() {
             // Check that tensor has sub-tensors and doesn't have external legs set
             if !tensor.tensors().is_empty() && tensor.legs().is_empty() {
-                let mut bb = BranchBound::new(
-                    &tensor,
-                    self.nbranch,
-                    self.cutoff_flops_factor,
-                    self.minimize,
-                );
-                let result = bb.find_path();
+                let mut bb =
+                    BranchBound::new(self.nbranch, self.cutoff_flops_factor, self.minimize);
+                let result = bb.find_path(&tensor);
                 nested_paths.insert(index, result.ssa_path().clone());
                 tensor = tensor.external_tensor();
             }
@@ -207,8 +197,8 @@ impl Pathfinder for BranchBound<'_> {
 
             self.tensor_cache.insert_new(index, tensor);
         }
-        let remaining = (0..self.tn.tensors().len()).collect_vec();
-        self.branch_iterate(&[], &remaining, 0f64, 0f64);
+        let remaining = (0..tensor.tensors().len()).collect_vec();
+        self.branch_iterate(tensor, &[], &remaining, 0f64, 0f64);
         let best_path = ContractionPath {
             nested: nested_paths,
             toplevel: std::mem::take(&mut self.best_path).into_simple(),
@@ -269,8 +259,8 @@ mod tests {
     #[test]
     fn test_contract_order_simple() {
         let tn = setup_simple();
-        let mut opt = BranchBound::new(&tn, None, 20., CostType::Flops);
-        let result = opt.find_path();
+        let mut opt = BranchBound::new(None, 20., CostType::Flops);
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,
@@ -285,8 +275,8 @@ mod tests {
     #[test]
     fn test_contract_order_complex() {
         let tn = setup_complex();
-        let mut opt = BranchBound::new(&tn, None, 20., CostType::Flops);
-        let result = opt.find_path();
+        let mut opt = BranchBound::new(None, 20., CostType::Flops);
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,

--- a/tnc/src/contractionpath/paths/cotengrust.rs
+++ b/tnc/src/contractionpath/paths/cotengrust.rs
@@ -123,8 +123,7 @@ impl Pathfinder for Cotengrust {
         let mut inputs = tensor.tensors().clone();
         for (index, input_tensor) in inputs.iter_mut().enumerate() {
             if input_tensor.is_composite() {
-                let mut ct = Cotengrust::new(self.opt_method);
-                let result = ct.find_path(input_tensor);
+                let result = self.find_path(input_tensor);
                 nested_paths.insert(index, result.ssa_path().clone());
                 *input_tensor = input_tensor.external_tensor();
             }

--- a/tnc/src/contractionpath/paths/cotengrust.rs
+++ b/tnc/src/contractionpath/paths/cotengrust.rs
@@ -5,7 +5,9 @@ use itertools::Itertools;
 use rustc_hash::FxHashMap;
 
 use crate::contractionpath::contraction_cost::contract_path_cost;
-use crate::contractionpath::paths::FindPath;
+use crate::contractionpath::paths::{
+    BasicContractionPathResult, ContractionPathResult, Pathfinder,
+};
 use crate::contractionpath::{ssa_replace_ordering, ContractionPath, SimplePath};
 use crate::tensornetwork::tensor::Tensor;
 
@@ -24,22 +26,13 @@ pub enum OptMethod {
 #[derive(Debug, Clone)]
 pub struct Cotengrust<'a> {
     tensor: &'a Tensor,
-    best_path: ContractionPath,
-    best_flops: f64,
-    best_size: f64,
     opt_method: OptMethod,
 }
 
 impl<'a> Cotengrust<'a> {
     /// Creates a new Cotengrust optimizer using the specified optimization method.
     pub fn new(tensor: &'a Tensor, opt_method: OptMethod) -> Self {
-        Self {
-            tensor,
-            opt_method,
-            best_path: ContractionPath::default(),
-            best_flops: f64::INFINITY,
-            best_size: f64::INFINITY,
-        }
+        Self { tensor, opt_method }
     }
 
     /// Finds a contraction path for a "classical" tensor network, i.e. the inputs
@@ -121,16 +114,18 @@ fn tensor_legs_to_digit(
     (new_inputs, new_output, new_size_dict)
 }
 
-impl FindPath for Cotengrust<'_> {
-    fn find_path(&mut self) {
+impl Pathfinder for Cotengrust<'_> {
+    type Result = BasicContractionPathResult;
+
+    fn find_path(&mut self) -> BasicContractionPathResult {
         // Handle nested tensors first
         let mut nested_paths = FxHashMap::default();
         let mut inputs = self.tensor.tensors().clone();
         for (index, input_tensor) in inputs.iter_mut().enumerate() {
             if input_tensor.is_composite() {
                 let mut ct = Cotengrust::new(input_tensor, self.opt_method);
-                ct.find_path();
-                nested_paths.insert(index, ct.get_best_path().clone());
+                let result = ct.find_path();
+                nested_paths.insert(index, result.ssa_path().clone());
                 *input_tensor = input_tensor.external_tensor();
             }
         }
@@ -138,32 +133,19 @@ impl FindPath for Cotengrust<'_> {
         // Now handle the outer tensor
         let external_tensor = self.tensor.external_tensor();
         let outer_path = self.optimize_single(&inputs, &external_tensor);
-        self.best_path = ContractionPath {
+        let best_path = ContractionPath {
             nested: nested_paths,
             toplevel: outer_path,
         };
+        let replace_path = ssa_replace_ordering(&best_path);
 
         // Compute the cost
-        let (op_cost, mem_cost) =
-            contract_path_cost(self.tensor.tensors(), &self.get_best_replace_path(), true);
-        self.best_size = mem_cost;
-        self.best_flops = op_cost;
-    }
-
-    fn get_best_path(&self) -> &ContractionPath {
-        &self.best_path
-    }
-
-    fn get_best_replace_path(&self) -> ContractionPath {
-        ssa_replace_ordering(&self.best_path)
-    }
-
-    fn get_best_flops(&self) -> f64 {
-        self.best_flops
-    }
-
-    fn get_best_size(&self) -> f64 {
-        self.best_size
+        let (op_cost, mem_cost) = contract_path_cost(self.tensor.tensors(), &replace_path, true);
+        BasicContractionPathResult {
+            ssa_path: best_path,
+            flops: op_cost,
+            size: mem_cost,
+        }
     }
 }
 
@@ -242,65 +224,79 @@ mod tests {
     fn test_contract_order_greedy_simple() {
         let tn = setup_simple();
         let mut opt = Cotengrust::new(&tn, OptMethod::Greedy);
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.get_best_flops(), 600.);
-        assert_eq!(opt.get_best_size(), 538.);
-        assert_eq!(opt.get_best_path(), &path![(0, 1), (3, 2)]);
-        assert_eq!(opt.get_best_replace_path(), path![(0, 1), (0, 2)]);
+        assert_eq!(
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(0, 1), (3, 2)],
+                flops: 600.,
+                size: 538.
+            }
+        );
     }
 
     #[test]
     fn test_contract_order_greedy_simple_inner() {
         let tn = setup_simple_inner_product();
         let mut opt = Cotengrust::new(&tn, OptMethod::Greedy);
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.get_best_flops(), 228.);
-        assert_eq!(opt.get_best_size(), 121.);
-        assert_eq!(opt.get_best_path(), &path![(0, 1), (2, 3), (4, 5)]);
-        assert_eq!(opt.get_best_replace_path(), path![(0, 1), (2, 3), (0, 2)]);
+        assert_eq!(
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(0, 1), (2, 3), (4, 5)],
+                flops: 228.,
+                size: 121.
+            }
+        );
     }
 
     #[test]
     fn test_contract_order_greedy_simple_outer() {
         let tn = setup_simple_outer_product();
         let mut opt = Cotengrust::new(&tn, OptMethod::Greedy);
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.get_best_flops(), 16.);
-        assert_eq!(opt.get_best_size(), 19.);
-        assert_eq!(opt.get_best_path(), &path![(2, 1), (0, 3)]);
-        assert_eq!(opt.get_best_replace_path(), path![(2, 1), (0, 2)]);
+        assert_eq!(
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(2, 1), (0, 3)],
+                flops: 16.,
+                size: 19.
+            }
+        );
     }
 
     #[test]
     fn test_contract_order_greedy_complex_outer() {
         let tn = setup_complex_outer_product();
         let mut opt = Cotengrust::new(&tn, OptMethod::Greedy);
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.get_best_flops(), 10.);
-        assert_eq!(opt.get_best_size(), 11.);
-        assert_eq!(opt.get_best_path(), &path![(0, 1), (2, 3), (5, 4)]);
-        assert_eq!(opt.get_best_replace_path(), path![(0, 1), (2, 3), (2, 0)]);
+        assert_eq!(
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(0, 1), (2, 3), (5, 4)],
+                flops: 10.,
+                size: 11.
+            }
+        );
     }
 
     #[test]
     fn test_contract_order_greedy_complex() {
         let tn = setup_complex();
         let mut opt = Cotengrust::new(&tn, OptMethod::Greedy);
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.get_best_flops(), 529815.);
-        assert_eq!(opt.get_best_size(), 89478.);
         assert_eq!(
-            opt.get_best_path(),
-            &path![(1, 5), (3, 4), (6, 0), (7, 2), (9, 8)]
-        );
-        assert_eq!(
-            opt.get_best_replace_path(),
-            path![(1, 5), (3, 4), (1, 0), (3, 2), (3, 1)]
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(1, 5), (3, 4), (6, 0), (7, 2), (9, 8)],
+                flops: 529815.,
+                size: 89478.
+            }
         );
     }
 }

--- a/tnc/src/contractionpath/paths/cotengrust.rs
+++ b/tnc/src/contractionpath/paths/cotengrust.rs
@@ -24,15 +24,15 @@ pub enum OptMethod {
 
 /// A contraction path finder using the `cotengrust` library.
 #[derive(Debug, Clone)]
-pub struct Cotengrust<'a> {
-    tensor: &'a Tensor,
+pub struct Cotengrust {
     opt_method: OptMethod,
 }
 
-impl<'a> Cotengrust<'a> {
+impl Cotengrust {
     /// Creates a new Cotengrust optimizer using the specified optimization method.
-    pub fn new(tensor: &'a Tensor, opt_method: OptMethod) -> Self {
-        Self { tensor, opt_method }
+    #[inline]
+    pub fn new(opt_method: OptMethod) -> Self {
+        Self { opt_method }
     }
 
     /// Finds a contraction path for a "classical" tensor network, i.e. the inputs
@@ -114,24 +114,24 @@ fn tensor_legs_to_digit(
     (new_inputs, new_output, new_size_dict)
 }
 
-impl Pathfinder for Cotengrust<'_> {
+impl Pathfinder for Cotengrust {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self) -> BasicContractionPathResult {
+    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
         // Handle nested tensors first
         let mut nested_paths = FxHashMap::default();
-        let mut inputs = self.tensor.tensors().clone();
+        let mut inputs = tensor.tensors().clone();
         for (index, input_tensor) in inputs.iter_mut().enumerate() {
             if input_tensor.is_composite() {
-                let mut ct = Cotengrust::new(input_tensor, self.opt_method);
-                let result = ct.find_path();
+                let mut ct = Cotengrust::new(self.opt_method);
+                let result = ct.find_path(input_tensor);
                 nested_paths.insert(index, result.ssa_path().clone());
                 *input_tensor = input_tensor.external_tensor();
             }
         }
 
         // Now handle the outer tensor
-        let external_tensor = self.tensor.external_tensor();
+        let external_tensor = tensor.external_tensor();
         let outer_path = self.optimize_single(&inputs, &external_tensor);
         let best_path = ContractionPath {
             nested: nested_paths,
@@ -140,7 +140,7 @@ impl Pathfinder for Cotengrust<'_> {
         let replace_path = ssa_replace_ordering(&best_path);
 
         // Compute the cost
-        let (op_cost, mem_cost) = contract_path_cost(self.tensor.tensors(), &replace_path, true);
+        let (op_cost, mem_cost) = contract_path_cost(tensor.tensors(), &replace_path, true);
         BasicContractionPathResult {
             ssa_path: best_path,
             flops: op_cost,
@@ -223,8 +223,8 @@ mod tests {
     #[test]
     fn test_contract_order_greedy_simple() {
         let tn = setup_simple();
-        let mut opt = Cotengrust::new(&tn, OptMethod::Greedy);
-        let result = opt.find_path();
+        let mut opt = Cotengrust::new(OptMethod::Greedy);
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,
@@ -239,8 +239,8 @@ mod tests {
     #[test]
     fn test_contract_order_greedy_simple_inner() {
         let tn = setup_simple_inner_product();
-        let mut opt = Cotengrust::new(&tn, OptMethod::Greedy);
-        let result = opt.find_path();
+        let mut opt = Cotengrust::new(OptMethod::Greedy);
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,
@@ -255,8 +255,8 @@ mod tests {
     #[test]
     fn test_contract_order_greedy_simple_outer() {
         let tn = setup_simple_outer_product();
-        let mut opt = Cotengrust::new(&tn, OptMethod::Greedy);
-        let result = opt.find_path();
+        let mut opt = Cotengrust::new(OptMethod::Greedy);
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,
@@ -271,8 +271,8 @@ mod tests {
     #[test]
     fn test_contract_order_greedy_complex_outer() {
         let tn = setup_complex_outer_product();
-        let mut opt = Cotengrust::new(&tn, OptMethod::Greedy);
-        let result = opt.find_path();
+        let mut opt = Cotengrust::new(OptMethod::Greedy);
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,
@@ -287,8 +287,8 @@ mod tests {
     #[test]
     fn test_contract_order_greedy_complex() {
         let tn = setup_complex();
-        let mut opt = Cotengrust::new(&tn, OptMethod::Greedy);
-        let result = opt.find_path();
+        let mut opt = Cotengrust::new(OptMethod::Greedy);
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,

--- a/tnc/src/contractionpath/paths/hyperoptimization.rs
+++ b/tnc/src/contractionpath/paths/hyperoptimization.rs
@@ -5,7 +5,7 @@ use rustengra::hyper::cotengra_hyperoptimizer;
 use crate::{
     contractionpath::{
         contraction_cost::contract_path_cost,
-        paths::{CostType, FindPath},
+        paths::{BasicContractionPathResult, ContractionPathResult, CostType, Pathfinder},
         ssa_replace_ordering, ContractionPath,
     },
     tensornetwork::tensor::Tensor,
@@ -18,9 +18,6 @@ pub use rustengra::hyper::HyperOptions;
 pub struct Hyperoptimizer<'a> {
     tensor: &'a Tensor,
     hyper_options: HyperOptions,
-    best_flops: f64,
-    best_size: f64,
-    best_path: ContractionPath,
 }
 
 impl<'a> Hyperoptimizer<'a> {
@@ -33,15 +30,14 @@ impl<'a> Hyperoptimizer<'a> {
         Self {
             tensor,
             hyper_options,
-            best_flops: f64::INFINITY,
-            best_size: f64::INFINITY,
-            best_path: ContractionPath::default(),
         }
     }
 }
 
-impl FindPath for Hyperoptimizer<'_> {
-    fn find_path(&mut self) {
+impl Pathfinder for Hyperoptimizer<'_> {
+    type Result = BasicContractionPathResult;
+
+    fn find_path(&mut self) -> BasicContractionPathResult {
         // Handle nested tensors first
         let mut nested_paths = FxHashMap::default();
         let inputs = self
@@ -53,8 +49,8 @@ impl FindPath for Hyperoptimizer<'_> {
                 if tensor.is_composite() {
                     let mut hp =
                         Hyperoptimizer::new(tensor, CostType::Flops, self.hyper_options.clone());
-                    hp.find_path();
-                    nested_paths.insert(index, hp.get_best_path().clone());
+                    let result = hp.find_path();
+                    nested_paths.insert(index, result.ssa_path().clone());
                     tensor.external_tensor().legs
                 } else {
                     tensor.legs.clone()
@@ -80,32 +76,19 @@ impl FindPath for Hyperoptimizer<'_> {
         )
         .unwrap();
 
-        self.best_path = ContractionPath {
+        let best_path = ContractionPath {
             nested: nested_paths,
             toplevel: ssa_path,
         };
+        let replace_path = ssa_replace_ordering(&best_path);
 
-        let (op_cost, mem_cost) =
-            contract_path_cost(self.tensor.tensors(), &self.get_best_replace_path(), true);
+        let (op_cost, mem_cost) = contract_path_cost(self.tensor.tensors(), &&replace_path, true);
 
-        self.best_flops = op_cost;
-        self.best_size = mem_cost;
-    }
-
-    fn get_best_flops(&self) -> f64 {
-        self.best_flops
-    }
-
-    fn get_best_size(&self) -> f64 {
-        self.best_size
-    }
-
-    fn get_best_path(&self) -> &ContractionPath {
-        &self.best_path
-    }
-
-    fn get_best_replace_path(&self) -> ContractionPath {
-        ssa_replace_ordering(&self.best_path)
+        BasicContractionPathResult {
+            ssa_path: best_path,
+            flops: op_cost,
+            size: mem_cost,
+        }
     }
 }
 
@@ -116,7 +99,7 @@ mod tests {
     use rustc_hash::FxHashMap;
 
     use crate::{
-        contractionpath::paths::{CostType, FindPath},
+        contractionpath::paths::{CostType, Pathfinder},
         path,
         tensornetwork::tensor::Tensor,
     };
@@ -166,12 +149,16 @@ mod tests {
                 .with_max_repeats(16)
                 .with_parallel(false),
         );
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.best_flops, 600.);
-        assert_eq!(opt.best_size, 538.);
-        assert_eq!(opt.get_best_path(), &path![(0, 1), (2, 3)]);
-        assert_eq!(opt.get_best_replace_path(), path![(0, 1), (2, 0)]);
+        assert_eq!(
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(0, 1), (2, 3)],
+                flops: 600.,
+                size: 538.
+            }
+        );
     }
 
     #[test]
@@ -184,14 +171,15 @@ mod tests {
                 .with_max_repeats(32)
                 .with_parallel(false),
         );
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.best_flops, 332685.);
-        assert_eq!(opt.best_size, 89478.);
-        assert_eq!(opt.best_path, path![(1, 5), (0, 6), (2, 7), (3, 8), (4, 9)]);
         assert_eq!(
-            opt.get_best_replace_path(),
-            path![(1, 5), (0, 1), (2, 0), (3, 2), (4, 3)]
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(1, 5), (0, 6), (2, 7), (3, 8), (4, 9)],
+                flops: 332685.,
+                size: 89478.
+            }
         );
     }
 }

--- a/tnc/src/contractionpath/paths/hyperoptimization.rs
+++ b/tnc/src/contractionpath/paths/hyperoptimization.rs
@@ -76,7 +76,7 @@ impl Pathfinder for Hyperoptimizer {
         };
         let replace_path = ssa_replace_ordering(&best_path);
 
-        let (op_cost, mem_cost) = contract_path_cost(tensor.tensors(), &&replace_path, true);
+        let (op_cost, mem_cost) = contract_path_cost(tensor.tensors(), &replace_path, true);
 
         BasicContractionPathResult {
             ssa_path: best_path,

--- a/tnc/src/contractionpath/paths/hyperoptimization.rs
+++ b/tnc/src/contractionpath/paths/hyperoptimization.rs
@@ -15,41 +15,36 @@ pub use rustengra::hyper::HyperOptions;
 
 /// Creates an interface to access `Cotengra` methods in Rust. Specifically exposes
 /// `search` method of `HyperOptimizer`.
-pub struct Hyperoptimizer<'a> {
-    tensor: &'a Tensor,
+pub struct Hyperoptimizer {
     hyper_options: HyperOptions,
 }
 
-impl<'a> Hyperoptimizer<'a> {
-    pub fn new(tensor: &'a Tensor, minimize: CostType, hyper_options: HyperOptions) -> Self {
+impl Hyperoptimizer {
+    #[inline]
+    pub fn new(minimize: CostType, hyper_options: HyperOptions) -> Self {
         assert_eq!(
             minimize,
             CostType::Flops,
             "Currently, only Flops is supported"
         );
-        Self {
-            tensor,
-            hyper_options,
-        }
+        Self { hyper_options }
     }
 }
 
-impl Pathfinder for Hyperoptimizer<'_> {
+impl Pathfinder for Hyperoptimizer {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self) -> BasicContractionPathResult {
+    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
         // Handle nested tensors first
         let mut nested_paths = FxHashMap::default();
-        let inputs = self
-            .tensor
+        let inputs = tensor
             .tensors()
             .iter()
             .enumerate()
             .map(|(index, tensor)| {
                 if tensor.is_composite() {
-                    let mut hp =
-                        Hyperoptimizer::new(tensor, CostType::Flops, self.hyper_options.clone());
-                    let result = hp.find_path();
+                    let mut hp = Hyperoptimizer::new(CostType::Flops, self.hyper_options.clone());
+                    let result = hp.find_path(tensor);
                     nested_paths.insert(index, result.ssa_path().clone());
                     tensor.external_tensor().legs
                 } else {
@@ -58,8 +53,8 @@ impl Pathfinder for Hyperoptimizer<'_> {
             })
             .collect_vec();
 
-        let outputs = self.tensor.external_tensor();
-        let size_dict = self.tensor.tensors().iter().map(Tensor::edges).fold(
+        let outputs = tensor.external_tensor();
+        let size_dict = tensor.tensors().iter().map(Tensor::edges).fold(
             FxHashMap::default(),
             |mut acc, edges| {
                 acc.extend(edges);
@@ -82,7 +77,7 @@ impl Pathfinder for Hyperoptimizer<'_> {
         };
         let replace_path = ssa_replace_ordering(&best_path);
 
-        let (op_cost, mem_cost) = contract_path_cost(self.tensor.tensors(), &&replace_path, true);
+        let (op_cost, mem_cost) = contract_path_cost(tensor.tensors(), &&replace_path, true);
 
         BasicContractionPathResult {
             ssa_path: best_path,
@@ -143,13 +138,12 @@ mod tests {
     fn test_hyper_tree_contract_order_simple() {
         let tn = setup_simple();
         let mut opt = Hyperoptimizer::new(
-            &tn,
             CostType::Flops,
             HyperOptions::new()
                 .with_max_repeats(16)
                 .with_parallel(false),
         );
-        let result = opt.find_path();
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,
@@ -165,13 +159,12 @@ mod tests {
     fn test_hyper_tree_contract_order_complex() {
         let tn = setup_complex();
         let mut opt = Hyperoptimizer::new(
-            &tn,
             CostType::Flops,
             HyperOptions::new()
                 .with_max_repeats(32)
                 .with_parallel(false),
         );
-        let result = opt.find_path();
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,

--- a/tnc/src/contractionpath/paths/hyperoptimization.rs
+++ b/tnc/src/contractionpath/paths/hyperoptimization.rs
@@ -43,8 +43,7 @@ impl Pathfinder for Hyperoptimizer {
             .enumerate()
             .map(|(index, tensor)| {
                 if tensor.is_composite() {
-                    let mut hp = Hyperoptimizer::new(CostType::Flops, self.hyper_options.clone());
-                    let result = hp.find_path(tensor);
+                    let result = self.find_path(tensor);
                     nested_paths.insert(index, result.ssa_path().clone());
                     tensor.external_tensor().legs
                 } else {

--- a/tnc/src/contractionpath/paths/tree_annealing.rs
+++ b/tnc/src/contractionpath/paths/tree_annealing.rs
@@ -13,16 +13,14 @@ use crate::{
 
 /// Creates an interface to `rustengra` an interface to access `Cotengra` methods in
 /// Rust. Specifically exposes `simulated_anneal_tree` method.
-pub struct TreeAnnealing<'a> {
-    tensor: &'a Tensor,
+pub struct TreeAnnealing {
     temperature_steps: Option<usize>,
     numiter: Option<usize>,
     seed: Option<u64>,
 }
 
-impl<'a> TreeAnnealing<'a> {
+impl TreeAnnealing {
     pub fn new(
-        tensor: &'a Tensor,
         seed: Option<u64>,
         minimize: CostType,
         temperature_steps: Option<usize>,
@@ -35,7 +33,6 @@ impl<'a> TreeAnnealing<'a> {
             "Currently, only Flops is supported"
         );
         Self {
-            tensor,
             temperature_steps,
             numiter,
             seed,
@@ -43,19 +40,18 @@ impl<'a> TreeAnnealing<'a> {
     }
 }
 
-impl Pathfinder for TreeAnnealing<'_> {
+impl Pathfinder for TreeAnnealing {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self) -> BasicContractionPathResult {
+    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
         // Map tensors to legs
-        let inputs = self
-            .tensor
+        let inputs = tensor
             .tensors()
             .iter()
             .map(|tensor| tensor.legs().clone())
             .collect_vec();
-        let outputs = self.tensor.external_tensor();
-        let size_dict = self.tensor.tensors().iter().map(Tensor::edges).fold(
+        let outputs = tensor.external_tensor();
+        let size_dict = tensor.tensors().iter().map(Tensor::edges).fold(
             FxHashMap::default(),
             |mut acc, edges| {
                 acc.extend(edges);
@@ -76,7 +72,7 @@ impl Pathfinder for TreeAnnealing<'_> {
         let best_path = ContractionPath::simple(best_path);
         let replace_path = ssa_replace_ordering(&best_path);
 
-        let (op_cost, mem_cost) = contract_path_cost(self.tensor.tensors(), &replace_path, true);
+        let (op_cost, mem_cost) = contract_path_cost(tensor.tensors(), &replace_path, true);
 
         BasicContractionPathResult {
             ssa_path: best_path,
@@ -136,8 +132,8 @@ mod tests {
     #[test]
     fn test_anneal_tree_contract_order_simple() {
         let tn = setup_simple();
-        let mut opt = TreeAnnealing::new(&tn, Some(8), CostType::Flops, Some(100), Some(50));
-        let result = opt.find_path();
+        let mut opt = TreeAnnealing::new(Some(8), CostType::Flops, Some(100), Some(50));
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,
@@ -152,8 +148,8 @@ mod tests {
     #[test]
     fn test_anneal_tree_contract_order_complex() {
         let tn = setup_complex();
-        let mut opt = TreeAnnealing::new(&tn, Some(8), CostType::Flops, Some(100), Some(50));
-        let result = opt.find_path();
+        let mut opt = TreeAnnealing::new(Some(8), CostType::Flops, Some(100), Some(50));
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,

--- a/tnc/src/contractionpath/paths/tree_annealing.rs
+++ b/tnc/src/contractionpath/paths/tree_annealing.rs
@@ -5,7 +5,7 @@ use rustengra::{cotengra_check, cotengra_sa_tree};
 use crate::{
     contractionpath::{
         contraction_cost::contract_path_cost,
-        paths::{CostType, FindPath},
+        paths::{BasicContractionPathResult, CostType, Pathfinder},
         ssa_replace_ordering, ContractionPath,
     },
     tensornetwork::tensor::Tensor,
@@ -17,9 +17,6 @@ pub struct TreeAnnealing<'a> {
     tensor: &'a Tensor,
     temperature_steps: Option<usize>,
     numiter: Option<usize>,
-    best_flops: f64,
-    best_size: f64,
-    best_path: ContractionPath,
     seed: Option<u64>,
 }
 
@@ -41,16 +38,15 @@ impl<'a> TreeAnnealing<'a> {
             tensor,
             temperature_steps,
             numiter,
-            best_flops: f64::INFINITY,
-            best_size: f64::INFINITY,
-            best_path: ContractionPath::default(),
             seed,
         }
     }
 }
 
-impl FindPath for TreeAnnealing<'_> {
-    fn find_path(&mut self) {
+impl Pathfinder for TreeAnnealing<'_> {
+    type Result = BasicContractionPathResult;
+
+    fn find_path(&mut self) -> BasicContractionPathResult {
         // Map tensors to legs
         let inputs = self
             .tensor
@@ -77,29 +73,16 @@ impl FindPath for TreeAnnealing<'_> {
         )
         .unwrap();
 
-        self.best_path = ContractionPath::simple(best_path);
+        let best_path = ContractionPath::simple(best_path);
+        let replace_path = ssa_replace_ordering(&best_path);
 
-        let (op_cost, mem_cost) =
-            contract_path_cost(self.tensor.tensors(), &self.get_best_replace_path(), true);
+        let (op_cost, mem_cost) = contract_path_cost(self.tensor.tensors(), &replace_path, true);
 
-        self.best_flops = op_cost;
-        self.best_size = mem_cost;
-    }
-
-    fn get_best_flops(&self) -> f64 {
-        self.best_flops
-    }
-
-    fn get_best_size(&self) -> f64 {
-        self.best_size
-    }
-
-    fn get_best_path(&self) -> &ContractionPath {
-        &self.best_path
-    }
-
-    fn get_best_replace_path(&self) -> ContractionPath {
-        ssa_replace_ordering(&self.best_path)
+        BasicContractionPathResult {
+            ssa_path: best_path,
+            flops: op_cost,
+            size: mem_cost,
+        }
     }
 }
 
@@ -110,7 +93,7 @@ mod tests {
     use rustc_hash::FxHashMap;
 
     use crate::{
-        contractionpath::paths::{CostType, FindPath},
+        contractionpath::paths::{CostType, Pathfinder},
         path,
         tensornetwork::tensor::Tensor,
     };
@@ -154,26 +137,31 @@ mod tests {
     fn test_anneal_tree_contract_order_simple() {
         let tn = setup_simple();
         let mut opt = TreeAnnealing::new(&tn, Some(8), CostType::Flops, Some(100), Some(50));
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.best_flops, 600.);
-        assert_eq!(opt.best_size, 538.);
-        assert_eq!(opt.get_best_path(), &path![(0, 1), (2, 3)]);
-        assert_eq!(opt.get_best_replace_path(), path![(0, 1), (2, 0)]);
+        assert_eq!(
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(0, 1), (2, 3)],
+                flops: 600.,
+                size: 538.
+            }
+        );
     }
 
     #[test]
     fn test_anneal_tree_contract_order_complex() {
         let tn = setup_complex();
         let mut opt = TreeAnnealing::new(&tn, Some(8), CostType::Flops, Some(100), Some(50));
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.best_flops, 332685.);
-        assert_eq!(opt.best_size, 89478.);
-        assert_eq!(opt.best_path, path![(1, 5), (0, 6), (2, 7), (3, 8), (4, 9)]);
         assert_eq!(
-            opt.get_best_replace_path(),
-            path![(1, 5), (0, 1), (2, 0), (3, 2), (4, 3)]
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(1, 5), (0, 6), (2, 7), (3, 8), (4, 9)],
+                flops: 332685.,
+                size: 89478.
+            }
         );
     }
 }

--- a/tnc/src/contractionpath/paths/tree_reconfiguration.rs
+++ b/tnc/src/contractionpath/paths/tree_reconfiguration.rs
@@ -13,42 +13,37 @@ use crate::{
 
 /// Creates an interface to `rustengra` an interface to access `Cotengra` methods in
 /// Rust. Specifically exposes `subtree_reconfigure` method.
-pub struct TreeReconfigure<'a> {
-    tensor: &'a Tensor,
+pub struct TreeReconfigure {
     subtree_size: usize,
 }
 
-impl<'a> TreeReconfigure<'a> {
+impl TreeReconfigure {
     /// Creates a new [`TreeReconfigure`] instance. `subtree_size` is the
     /// size of subtrees that is considered (increases the optimization cost
     /// exponentially!).
-    pub fn new(tensor: &'a Tensor, subtree_size: usize, minimize: CostType) -> Self {
+    pub fn new(subtree_size: usize, minimize: CostType) -> Self {
         cotengra_check().expect("Needs python and cotengra installed");
         assert_eq!(
             minimize,
             CostType::Flops,
             "Currently, only Flops is supported"
         );
-        Self {
-            tensor,
-            subtree_size,
-        }
+        Self { subtree_size }
     }
 }
 
-impl Pathfinder for TreeReconfigure<'_> {
+impl Pathfinder for TreeReconfigure {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self) -> BasicContractionPathResult {
+    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
         // Map tensors to legs
-        let inputs = self
-            .tensor
+        let inputs = tensor
             .tensors()
             .iter()
             .map(|tensor| tensor.legs().clone())
             .collect_vec();
-        let outputs = self.tensor.external_tensor();
-        let size_dict = self.tensor.tensors().iter().map(Tensor::edges).fold(
+        let outputs = tensor.external_tensor();
+        let size_dict = tensor.tensors().iter().map(Tensor::edges).fold(
             FxHashMap::default(),
             |mut acc, edges| {
                 acc.extend(edges);
@@ -63,7 +58,7 @@ impl Pathfinder for TreeReconfigure<'_> {
         let best_path = ContractionPath::simple(best_path);
         let replace_path = ssa_replace_ordering(&best_path);
 
-        let (op_cost, mem_cost) = contract_path_cost(self.tensor.tensors(), &replace_path, true);
+        let (op_cost, mem_cost) = contract_path_cost(tensor.tensors(), &replace_path, true);
 
         BasicContractionPathResult {
             ssa_path: best_path,
@@ -123,8 +118,8 @@ mod tests {
     #[test]
     fn test_tree_contract_order_simple() {
         let tn = setup_simple();
-        let mut opt = TreeReconfigure::new(&tn, 8, CostType::Flops);
-        let result = opt.find_path();
+        let mut opt = TreeReconfigure::new(8, CostType::Flops);
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,
@@ -139,8 +134,8 @@ mod tests {
     #[test]
     fn test_tree_contract_order_complex() {
         let tn = setup_complex();
-        let mut opt = TreeReconfigure::new(&tn, 8, CostType::Flops);
-        let result = opt.find_path();
+        let mut opt = TreeReconfigure::new(8, CostType::Flops);
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,

--- a/tnc/src/contractionpath/paths/tree_reconfiguration.rs
+++ b/tnc/src/contractionpath/paths/tree_reconfiguration.rs
@@ -5,7 +5,7 @@ use rustengra::{cotengra_check, cotengra_optimized_greedy};
 use crate::{
     contractionpath::{
         contraction_cost::contract_path_cost,
-        paths::{CostType, FindPath},
+        paths::{BasicContractionPathResult, CostType, Pathfinder},
         ssa_replace_ordering, ContractionPath,
     },
     tensornetwork::tensor::Tensor,
@@ -16,9 +16,6 @@ use crate::{
 pub struct TreeReconfigure<'a> {
     tensor: &'a Tensor,
     subtree_size: usize,
-    best_flops: f64,
-    best_size: f64,
-    best_path: ContractionPath,
 }
 
 impl<'a> TreeReconfigure<'a> {
@@ -35,15 +32,14 @@ impl<'a> TreeReconfigure<'a> {
         Self {
             tensor,
             subtree_size,
-            best_flops: f64::INFINITY,
-            best_size: f64::INFINITY,
-            best_path: ContractionPath::default(),
         }
     }
 }
 
-impl FindPath for TreeReconfigure<'_> {
-    fn find_path(&mut self) {
+impl Pathfinder for TreeReconfigure<'_> {
+    type Result = BasicContractionPathResult;
+
+    fn find_path(&mut self) -> BasicContractionPathResult {
         // Map tensors to legs
         let inputs = self
             .tensor
@@ -64,29 +60,16 @@ impl FindPath for TreeReconfigure<'_> {
             cotengra_optimized_greedy(&inputs, outputs.legs(), &size_dict, self.subtree_size)
                 .unwrap();
 
-        self.best_path = ContractionPath::simple(best_path);
+        let best_path = ContractionPath::simple(best_path);
+        let replace_path = ssa_replace_ordering(&best_path);
 
-        let (op_cost, mem_cost) =
-            contract_path_cost(self.tensor.tensors(), &self.get_best_replace_path(), true);
+        let (op_cost, mem_cost) = contract_path_cost(self.tensor.tensors(), &replace_path, true);
 
-        self.best_flops = op_cost;
-        self.best_size = mem_cost;
-    }
-
-    fn get_best_flops(&self) -> f64 {
-        self.best_flops
-    }
-
-    fn get_best_size(&self) -> f64 {
-        self.best_size
-    }
-
-    fn get_best_path(&self) -> &ContractionPath {
-        &self.best_path
-    }
-
-    fn get_best_replace_path(&self) -> ContractionPath {
-        ssa_replace_ordering(&self.best_path)
+        BasicContractionPathResult {
+            ssa_path: best_path,
+            flops: op_cost,
+            size: mem_cost,
+        }
     }
 }
 
@@ -97,7 +80,7 @@ mod tests {
     use rustc_hash::FxHashMap;
 
     use crate::{
-        contractionpath::paths::{CostType, FindPath},
+        contractionpath::paths::{CostType, Pathfinder},
         path,
         tensornetwork::tensor::Tensor,
     };
@@ -141,26 +124,31 @@ mod tests {
     fn test_tree_contract_order_simple() {
         let tn = setup_simple();
         let mut opt = TreeReconfigure::new(&tn, 8, CostType::Flops);
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.best_flops, 600.);
-        assert_eq!(opt.best_size, 538.);
-        assert_eq!(opt.get_best_path(), &path![(0, 1), (2, 3)]);
-        assert_eq!(opt.get_best_replace_path(), path![(0, 1), (2, 0)]);
+        assert_eq!(
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(0, 1), (2, 3)],
+                flops: 600.,
+                size: 538.
+            }
+        );
     }
 
     #[test]
     fn test_tree_contract_order_complex() {
         let tn = setup_complex();
         let mut opt = TreeReconfigure::new(&tn, 8, CostType::Flops);
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.best_flops, 332685.);
-        assert_eq!(opt.best_size, 89478.);
-        assert_eq!(opt.best_path, path![(1, 5), (0, 6), (2, 7), (3, 8), (4, 9)]);
         assert_eq!(
-            opt.get_best_replace_path(),
-            path![(1, 5), (0, 1), (2, 0), (3, 2), (4, 3)]
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(1, 5), (0, 6), (2, 7), (3, 8), (4, 9)],
+                flops: 332685.,
+                size: 89478.
+            }
         );
     }
 }

--- a/tnc/src/contractionpath/paths/tree_tempering.rs
+++ b/tnc/src/contractionpath/paths/tree_tempering.rs
@@ -13,46 +13,35 @@ use crate::{
 
 /// Creates an interface to `rustengra` an interface to access `Cotengra` methods in
 /// Rust. Specifically exposes `parallel_temper_tree` method.
-pub struct TreeTempering<'a> {
-    tensor: &'a Tensor,
+pub struct TreeTempering {
     numiter: Option<usize>,
     seed: Option<u64>,
 }
 
-impl<'a> TreeTempering<'a> {
-    pub fn new(
-        tensor: &'a Tensor,
-        seed: Option<u64>,
-        minimize: CostType,
-        numiter: Option<usize>,
-    ) -> Self {
+impl TreeTempering {
+    pub fn new(seed: Option<u64>, minimize: CostType, numiter: Option<usize>) -> Self {
         cotengra_check().expect("Needs python and cotengra installed");
         assert_eq!(
             minimize,
             CostType::Flops,
             "Currently, only Flops is supported"
         );
-        Self {
-            tensor,
-            numiter,
-            seed,
-        }
+        Self { numiter, seed }
     }
 }
 
-impl Pathfinder for TreeTempering<'_> {
+impl Pathfinder for TreeTempering {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self) -> BasicContractionPathResult {
+    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
         // Map tensors to legs
-        let inputs = self
-            .tensor
+        let inputs = tensor
             .tensors()
             .iter()
             .map(|tensor| tensor.legs().clone())
             .collect_vec();
-        let outputs = self.tensor.external_tensor();
-        let size_dict = self.tensor.tensors().iter().map(Tensor::edges).fold(
+        let outputs = tensor.external_tensor();
+        let size_dict = tensor.tensors().iter().map(Tensor::edges).fold(
             FxHashMap::default(),
             |mut acc, edges| {
                 acc.extend(edges);
@@ -67,7 +56,7 @@ impl Pathfinder for TreeTempering<'_> {
         let best_path = ContractionPath::simple(best_path);
         let replace_path = ssa_replace_ordering(&best_path);
 
-        let (op_cost, mem_cost) = contract_path_cost(self.tensor.tensors(), &replace_path, true);
+        let (op_cost, mem_cost) = contract_path_cost(tensor.tensors(), &replace_path, true);
 
         BasicContractionPathResult {
             ssa_path: best_path,
@@ -128,8 +117,8 @@ mod tests {
     #[ignore = "flaky test due to a bug in cotengra"]
     fn test_temper_tree_contract_order_simple() {
         let tn = setup_simple();
-        let mut opt = TreeTempering::new(&tn, Some(8), CostType::Flops, Some(100));
-        let result = opt.find_path();
+        let mut opt = TreeTempering::new(Some(8), CostType::Flops, Some(100));
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,
@@ -145,8 +134,8 @@ mod tests {
     #[ignore = "flaky test due to a bug in cotengra"]
     fn test_temper_tree_contract_order_complex() {
         let tn = setup_complex();
-        let mut opt = TreeTempering::new(&tn, Some(8), CostType::Flops, Some(100));
-        let result = opt.find_path();
+        let mut opt = TreeTempering::new(Some(8), CostType::Flops, Some(100));
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,

--- a/tnc/src/contractionpath/paths/tree_tempering.rs
+++ b/tnc/src/contractionpath/paths/tree_tempering.rs
@@ -5,7 +5,7 @@ use rustengra::{cotengra_check, cotengra_tree_tempering};
 use crate::{
     contractionpath::{
         contraction_cost::contract_path_cost,
-        paths::{CostType, FindPath},
+        paths::{BasicContractionPathResult, CostType, Pathfinder},
         ssa_replace_ordering, ContractionPath,
     },
     tensornetwork::tensor::Tensor,
@@ -16,9 +16,6 @@ use crate::{
 pub struct TreeTempering<'a> {
     tensor: &'a Tensor,
     numiter: Option<usize>,
-    best_flops: f64,
-    best_size: f64,
-    best_path: ContractionPath,
     seed: Option<u64>,
 }
 
@@ -38,16 +35,15 @@ impl<'a> TreeTempering<'a> {
         Self {
             tensor,
             numiter,
-            best_flops: f64::INFINITY,
-            best_size: f64::INFINITY,
-            best_path: ContractionPath::default(),
             seed,
         }
     }
 }
 
-impl FindPath for TreeTempering<'_> {
-    fn find_path(&mut self) {
+impl Pathfinder for TreeTempering<'_> {
+    type Result = BasicContractionPathResult;
+
+    fn find_path(&mut self) -> BasicContractionPathResult {
         // Map tensors to legs
         let inputs = self
             .tensor
@@ -68,29 +64,16 @@ impl FindPath for TreeTempering<'_> {
             cotengra_tree_tempering(&inputs, outputs.legs(), self.numiter, &size_dict, self.seed)
                 .unwrap();
 
-        self.best_path = ContractionPath::simple(best_path);
+        let best_path = ContractionPath::simple(best_path);
+        let replace_path = ssa_replace_ordering(&best_path);
 
-        let (op_cost, mem_cost) =
-            contract_path_cost(self.tensor.tensors(), &self.get_best_replace_path(), true);
+        let (op_cost, mem_cost) = contract_path_cost(self.tensor.tensors(), &replace_path, true);
 
-        self.best_flops = op_cost;
-        self.best_size = mem_cost;
-    }
-
-    fn get_best_flops(&self) -> f64 {
-        self.best_flops
-    }
-
-    fn get_best_size(&self) -> f64 {
-        self.best_size
-    }
-
-    fn get_best_path(&self) -> &ContractionPath {
-        &self.best_path
-    }
-
-    fn get_best_replace_path(&self) -> ContractionPath {
-        ssa_replace_ordering(&self.best_path)
+        BasicContractionPathResult {
+            ssa_path: best_path,
+            flops: op_cost,
+            size: mem_cost,
+        }
     }
 }
 
@@ -101,7 +84,7 @@ mod tests {
     use rustc_hash::FxHashMap;
 
     use crate::{
-        contractionpath::paths::{CostType, FindPath},
+        contractionpath::paths::{CostType, Pathfinder},
         path,
         tensornetwork::tensor::Tensor,
     };
@@ -146,12 +129,16 @@ mod tests {
     fn test_temper_tree_contract_order_simple() {
         let tn = setup_simple();
         let mut opt = TreeTempering::new(&tn, Some(8), CostType::Flops, Some(100));
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.best_flops, 600.);
-        assert_eq!(opt.best_size, 538.);
-        assert_eq!(opt.get_best_path(), &path![(0, 1), (2, 3)]);
-        assert_eq!(opt.get_best_replace_path(), path![(0, 1), (2, 0)]);
+        assert_eq!(
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(0, 1), (2, 3)],
+                flops: 600.,
+                size: 538.
+            }
+        );
     }
 
     #[test]
@@ -159,14 +146,15 @@ mod tests {
     fn test_temper_tree_contract_order_complex() {
         let tn = setup_complex();
         let mut opt = TreeTempering::new(&tn, Some(8), CostType::Flops, Some(100));
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.best_flops, 332685.);
-        assert_eq!(opt.best_size, 89478.);
-        assert_eq!(opt.best_path, path![(1, 5), (0, 6), (2, 7), (3, 8), (4, 9)]);
         assert_eq!(
-            opt.get_best_replace_path(),
-            path![(1, 5), (0, 1), (2, 0), (3, 2), (4, 3)]
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(1, 5), (0, 6), (2, 7), (3, 8), (4, 9)],
+                flops: 332685.,
+                size: 89478.
+            }
         );
     }
 }

--- a/tnc/src/contractionpath/paths/weighted_branchbound.rs
+++ b/tnc/src/contractionpath/paths/weighted_branchbound.rs
@@ -7,8 +7,8 @@ use crate::{
     contractionpath::{
         candidates::Candidate,
         contraction_cost::{contract_op_cost_tensors, contract_size_tensors},
-        paths::{CostType, FindPath},
-        ssa_ordering, ssa_replace_ordering, ContractionPath,
+        paths::{BasicContractionPathResult, ContractionPathResult, CostType, Pathfinder},
+        ssa_ordering, ContractionPath,
     },
     tensornetwork::tensor::Tensor,
     utils::traits::HashMapInsertNew,
@@ -168,10 +168,12 @@ impl<'a> WeightedBranchBound<'a> {
     }
 }
 
-impl FindPath for WeightedBranchBound<'_> {
-    fn find_path(&mut self) {
+impl Pathfinder for WeightedBranchBound<'_> {
+    type Result = BasicContractionPathResult;
+
+    fn find_path(&mut self) -> BasicContractionPathResult {
         if self.tn.is_leaf() {
-            return;
+            return BasicContractionPathResult::default();
         }
         let tensors = self.tn.tensors().clone();
         self.result_cache.clear();
@@ -194,34 +196,23 @@ impl FindPath for WeightedBranchBound<'_> {
                     self.comm_cache.clone(),
                     self.minimize,
                 );
-                bb.find_path();
-                nested_paths.insert(index, bb.get_best_path().clone());
+                let result = bb.find_path();
+                nested_paths.insert(index, result.ssa_path().clone());
                 tensor = tensor.external_tensor();
             }
             self.tensor_cache.insert_new(index, tensor);
         }
         let remaining = (0..self.tn.tensors().len()).collect_vec();
         self.branch_iterate(&[], &remaining, 0f64, 0f64);
-        self.best_path = ContractionPath {
+        let best_path = ContractionPath {
             nested: nested_paths,
             toplevel: std::mem::take(&mut self.best_path).into_simple(),
         };
-    }
-
-    fn get_best_flops(&self) -> f64 {
-        self.best_flops
-    }
-
-    fn get_best_size(&self) -> f64 {
-        self.best_size
-    }
-
-    fn get_best_path(&self) -> &ContractionPath {
-        &self.best_path
-    }
-
-    fn get_best_replace_path(&self) -> ContractionPath {
-        ssa_replace_ordering(&self.best_path)
+        BasicContractionPathResult {
+            ssa_path: best_path,
+            flops: self.best_flops,
+            size: self.best_size,
+        }
     }
 }
 
@@ -232,7 +223,7 @@ mod tests {
     use rustc_hash::FxHashMap;
 
     use crate::contractionpath::paths::CostType;
-    use crate::contractionpath::paths::FindPath;
+    use crate::contractionpath::paths::Pathfinder;
     use crate::path;
     use crate::tensornetwork::tensor::Tensor;
 
@@ -281,26 +272,31 @@ mod tests {
     fn test_contract_order_simple() {
         let (tn, latency_costs) = setup_simple();
         let mut opt = WeightedBranchBound::new(&tn, None, 20., latency_costs, CostType::Flops);
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.best_flops, 640.);
-        assert_eq!(opt.best_size, 538.);
-        assert_eq!(opt.get_best_path(), &path![(1, 0), (2, 3)]);
-        assert_eq!(opt.get_best_replace_path(), path![(1, 0), (2, 1)]);
+        assert_eq!(
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(1, 0), (2, 3)],
+                flops: 640.,
+                size: 538.
+            }
+        );
     }
 
     #[test]
     fn test_contract_order_complex() {
         let (tn, latency_costs) = setup_complex();
         let mut opt = WeightedBranchBound::new(&tn, None, 20., latency_costs, CostType::Flops);
-        opt.find_path();
+        let result = opt.find_path();
 
-        assert_eq!(opt.best_flops, 265230.);
-        assert_eq!(opt.best_size, 89478.);
-        assert_eq!(opt.best_path, path![(3, 4), (2, 6), (1, 5), (0, 8), (7, 9)]);
         assert_eq!(
-            opt.get_best_replace_path(),
-            path![(3, 4), (2, 3), (1, 5), (0, 1), (2, 0)]
+            result,
+            BasicContractionPathResult {
+                ssa_path: path![(3, 4), (2, 6), (1, 5), (0, 8), (7, 9)],
+                flops: 265230.,
+                size: 89478.
+            }
         );
     }
 }

--- a/tnc/src/contractionpath/paths/weighted_branchbound.rs
+++ b/tnc/src/contractionpath/paths/weighted_branchbound.rs
@@ -14,9 +14,8 @@ use crate::{
     utils::traits::HashMapInsertNew,
 };
 
-/// A struct with an [`FindPath`] implementation that explores possible pair contractions in a depth-first manner.
-pub struct WeightedBranchBound<'a> {
-    tn: &'a Tensor,
+/// A struct with an [`Pathfinder`] implementation that explores possible pair contractions in a depth-first manner.
+pub struct WeightedBranchBound {
     nbranch: Option<usize>,
     cutoff_flops_factor: f64,
     minimize: CostType,
@@ -30,16 +29,14 @@ pub struct WeightedBranchBound<'a> {
     tensor_cache: FxHashMap<usize, Tensor>,
 }
 
-impl<'a> WeightedBranchBound<'a> {
+impl WeightedBranchBound {
     pub fn new(
-        tn: &'a Tensor,
         nbranch: Option<usize>,
         cutoff_flops_factor: f64,
         latency_map: FxHashMap<usize, f64>,
         minimize: CostType,
     ) -> Self {
         Self {
-            tn,
             nbranch,
             cutoff_flops_factor,
             minimize,
@@ -111,6 +108,7 @@ impl<'a> WeightedBranchBound<'a> {
     /// the Python based `opt_einsum` implementation. Found at <https://github.com/dgasmith/opt_einsum>.
     fn branch_iterate(
         &mut self,
+        tensor: &Tensor,
         path: &[(usize, usize, usize)],
         remaining: &[usize],
         flops: f64,
@@ -122,14 +120,14 @@ impl<'a> WeightedBranchBound<'a> {
                     if self.best_flops > flops {
                         self.best_flops = flops;
                         self.best_size = size;
-                        self.best_path = ssa_ordering(path, self.tn.tensors().len());
+                        self.best_path = ssa_ordering(path, tensor.tensors().len());
                     }
                 }
                 CostType::Size => {
                     if self.best_size > size {
                         self.best_flops = flops;
                         self.best_size = size;
-                        self.best_path = ssa_ordering(path, self.tn.tensors().len());
+                        self.best_path = ssa_ordering(path, tensor.tensors().len());
                     }
                 }
             }
@@ -162,20 +160,20 @@ impl<'a> WeightedBranchBound<'a> {
             new_remaining.retain(|e| *e != parent_ids.0 && *e != parent_ids.1);
             new_remaining.push(child_id);
             new_path.push((parent_ids.0, parent_ids.1, child_id));
-            self.branch_iterate(&new_path, &new_remaining, flop_cost, size_cost);
+            self.branch_iterate(tensor, &new_path, &new_remaining, flop_cost, size_cost);
             new_path.pop();
         }
     }
 }
 
-impl Pathfinder for WeightedBranchBound<'_> {
+impl Pathfinder for WeightedBranchBound {
     type Result = BasicContractionPathResult;
 
-    fn find_path(&mut self) -> BasicContractionPathResult {
-        if self.tn.is_leaf() {
+    fn find_path(&mut self, tensor: &Tensor) -> BasicContractionPathResult {
+        if tensor.is_leaf() {
             return BasicContractionPathResult::default();
         }
-        let tensors = self.tn.tensors().clone();
+        let tensors = tensor.tensors().clone();
         self.result_cache.clear();
         self.tensor_cache.clear();
         self.largest_latency = *self
@@ -190,20 +188,19 @@ impl Pathfinder for WeightedBranchBound<'_> {
             // Check that tensor has sub-tensors and doesn't have external legs set
             if tensor.is_composite() && tensor.legs().is_empty() {
                 let mut bb = WeightedBranchBound::new(
-                    &tensor,
                     self.nbranch,
                     self.cutoff_flops_factor,
                     self.comm_cache.clone(),
                     self.minimize,
                 );
-                let result = bb.find_path();
+                let result = bb.find_path(&tensor);
                 nested_paths.insert(index, result.ssa_path().clone());
                 tensor = tensor.external_tensor();
             }
             self.tensor_cache.insert_new(index, tensor);
         }
-        let remaining = (0..self.tn.tensors().len()).collect_vec();
-        self.branch_iterate(&[], &remaining, 0f64, 0f64);
+        let remaining = (0..tensor.tensors().len()).collect_vec();
+        self.branch_iterate(tensor, &[], &remaining, 0f64, 0f64);
         let best_path = ContractionPath {
             nested: nested_paths,
             toplevel: std::mem::take(&mut self.best_path).into_simple(),
@@ -271,8 +268,8 @@ mod tests {
     #[test]
     fn test_contract_order_simple() {
         let (tn, latency_costs) = setup_simple();
-        let mut opt = WeightedBranchBound::new(&tn, None, 20., latency_costs, CostType::Flops);
-        let result = opt.find_path();
+        let mut opt = WeightedBranchBound::new(None, 20., latency_costs, CostType::Flops);
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,
@@ -287,8 +284,8 @@ mod tests {
     #[test]
     fn test_contract_order_complex() {
         let (tn, latency_costs) = setup_complex();
-        let mut opt = WeightedBranchBound::new(&tn, None, 20., latency_costs, CostType::Flops);
-        let result = opt.find_path();
+        let mut opt = WeightedBranchBound::new(None, 20., latency_costs, CostType::Flops);
+        let result = opt.find_path(&tn);
 
         assert_eq!(
             result,

--- a/tnc/src/contractionpath/repartitioning.rs
+++ b/tnc/src/contractionpath/repartitioning.rs
@@ -10,7 +10,7 @@ use crate::{
         contraction_cost::{communication_path_op_costs, contract_path_cost},
         paths::{
             cotengrust::{Cotengrust, OptMethod},
-            FindPath,
+            ContractionPathResult, Pathfinder,
         },
         ContractionPath,
     },
@@ -36,8 +36,8 @@ where
 
     // Find contraction path
     let mut greedy = Cotengrust::new(&partitioned_tn, OptMethod::Greedy);
-    greedy.find_path();
-    let path = greedy.get_best_replace_path();
+    let result = greedy.find_path();
+    let path = result.replace_path();
 
     // Store the local paths (and costs)
     let mut latency_map =

--- a/tnc/src/contractionpath/repartitioning.rs
+++ b/tnc/src/contractionpath/repartitioning.rs
@@ -35,8 +35,8 @@ where
     let partitioned_tn = partition_tensor_network(tensor.clone(), partitioning);
 
     // Find contraction path
-    let mut greedy = Cotengrust::new(&partitioned_tn, OptMethod::Greedy);
-    let result = greedy.find_path();
+    let mut greedy = Cotengrust::new(OptMethod::Greedy);
+    let result = greedy.find_path(&partitioned_tn);
     let path = result.replace_path();
 
     // Store the local paths (and costs)

--- a/tnc/src/contractionpath/repartitioning/simulated_annealing.rs
+++ b/tnc/src/contractionpath/repartitioning/simulated_annealing.rs
@@ -17,7 +17,7 @@ use crate::{
         contraction_cost::{compute_memory_requirements, contract_size_tensors_bytes},
         paths::{
             cotengrust::{Cotengrust, OptMethod},
-            FindPath,
+            ContractionPathResult, Pathfinder,
         },
         repartitioning::compute_solution,
         SimplePath,
@@ -323,13 +323,13 @@ impl OptModel for NaiveIntermediatePartitioningModel<'_> {
         }
 
         let mut from_opt = Cotengrust::new(&from_tensor, OptMethod::Greedy);
-        from_opt.find_path();
-        let from_path = from_opt.get_best_replace_path();
+        let result = from_opt.find_path();
+        let from_path = result.replace_path();
         contraction_paths[source_partition] = from_path.into_simple();
 
         let mut to_opt = Cotengrust::new(&to_tensor, OptMethod::Greedy);
-        to_opt.find_path();
-        let to_path = to_opt.get_best_replace_path();
+        let result = to_opt.find_path();
+        let to_path = result.replace_path();
         contraction_paths[target_partition] = to_path.into_simple();
 
         (partitioning, contraction_paths)
@@ -432,8 +432,8 @@ impl IntermediatePartitioningModel<'_> {
                 .map(|t| {
                     // Find path for this partition
                     let mut opt = Cotengrust::new(t, OptMethod::Greedy);
-                    opt.find_path();
-                    let path = opt.get_best_replace_path();
+                    let result = opt.find_path();
+                    let path = result.replace_path();
                     path.into_simple()
                 })
                 .collect()
@@ -546,13 +546,13 @@ impl OptModel for IntermediatePartitioningModel<'_> {
         }
 
         let mut from_opt = Cotengrust::new(&from_tensor, OptMethod::Greedy);
-        from_opt.find_path();
-        let from_path = from_opt.get_best_replace_path();
+        let result = from_opt.find_path();
+        let from_path = result.replace_path();
         contraction_paths[source_partition] = from_path.into_simple();
 
         let mut to_opt = Cotengrust::new(&to_tensor, OptMethod::Greedy);
-        to_opt.find_path();
-        let to_path = to_opt.get_best_replace_path();
+        let result = to_opt.find_path();
+        let to_path = result.replace_path();
         contraction_paths[target_partition] = to_path.into_simple();
 
         (partitioning, partition_tensors, contraction_paths)

--- a/tnc/src/contractionpath/repartitioning/simulated_annealing.rs
+++ b/tnc/src/contractionpath/repartitioning/simulated_annealing.rs
@@ -322,13 +322,13 @@ impl OptModel for NaiveIntermediatePartitioningModel<'_> {
             }
         }
 
-        let mut from_opt = Cotengrust::new(&from_tensor, OptMethod::Greedy);
-        let result = from_opt.find_path();
+        let mut from_opt = Cotengrust::new(OptMethod::Greedy);
+        let result = from_opt.find_path(&from_tensor);
         let from_path = result.replace_path();
         contraction_paths[source_partition] = from_path.into_simple();
 
-        let mut to_opt = Cotengrust::new(&to_tensor, OptMethod::Greedy);
-        let result = to_opt.find_path();
+        let mut to_opt = Cotengrust::new(OptMethod::Greedy);
+        let result = to_opt.find_path(&to_tensor);
         let to_path = result.replace_path();
         contraction_paths[target_partition] = to_path.into_simple();
 
@@ -431,8 +431,8 @@ impl IntermediatePartitioningModel<'_> {
                 .iter()
                 .map(|t| {
                     // Find path for this partition
-                    let mut opt = Cotengrust::new(t, OptMethod::Greedy);
-                    let result = opt.find_path();
+                    let mut opt = Cotengrust::new(OptMethod::Greedy);
+                    let result = opt.find_path(t);
                     let path = result.replace_path();
                     path.into_simple()
                 })
@@ -545,13 +545,13 @@ impl OptModel for IntermediatePartitioningModel<'_> {
             }
         }
 
-        let mut from_opt = Cotengrust::new(&from_tensor, OptMethod::Greedy);
-        let result = from_opt.find_path();
+        let mut from_opt = Cotengrust::new(OptMethod::Greedy);
+        let result = from_opt.find_path(&from_tensor);
         let from_path = result.replace_path();
         contraction_paths[source_partition] = from_path.into_simple();
 
-        let mut to_opt = Cotengrust::new(&to_tensor, OptMethod::Greedy);
-        let result = to_opt.find_path();
+        let mut to_opt = Cotengrust::new(OptMethod::Greedy);
+        let result = to_opt.find_path(&to_tensor);
         let to_path = result.replace_path();
         contraction_paths[target_partition] = to_path.into_simple();
 

--- a/tnc/src/tensornetwork/contraction.rs
+++ b/tnc/src/tensornetwork/contraction.rs
@@ -26,8 +26,8 @@ use crate::{
 /// # use rand::SeedableRng;
 /// let mut r = StdRng::seed_from_u64(42);
 /// let mut r_tn = sycamore_circuit(2, 1, &mut r).into_expectation_value_network();
-/// let mut opt = Cotengrust::new(&r_tn, OptMethod::Greedy);
-/// let result = opt.find_path();
+/// let mut opt = Cotengrust::new(OptMethod::Greedy);
+/// let result = opt.find_path(&r_tn);
 /// let opt_path = result.replace_path();
 /// let result = contract_tensor_network(r_tn, &opt_path);
 /// ```

--- a/tnc/src/tensornetwork/contraction.rs
+++ b/tnc/src/tensornetwork/contraction.rs
@@ -17,7 +17,7 @@ use crate::{
 /// # Examples
 /// ```
 /// # use tnc::{
-/// #   contractionpath::paths::{cotengrust::{Cotengrust, OptMethod}, FindPath},
+/// #   contractionpath::paths::{cotengrust::{Cotengrust, OptMethod}, Pathfinder, ContractionPathResult},
 /// #   builders::sycamore_circuit::sycamore_circuit,
 /// #   tensornetwork::tensor::Tensor,
 /// #   tensornetwork::contraction::contract_tensor_network,
@@ -27,8 +27,8 @@ use crate::{
 /// let mut r = StdRng::seed_from_u64(42);
 /// let mut r_tn = sycamore_circuit(2, 1, &mut r).into_expectation_value_network();
 /// let mut opt = Cotengrust::new(&r_tn, OptMethod::Greedy);
-/// opt.find_path();
-/// let opt_path = opt.get_best_replace_path();
+/// let result = opt.find_path();
+/// let opt_path = result.replace_path();
 /// let result = contract_tensor_network(r_tn, &opt_path);
 /// ```
 pub fn contract_tensor_network(mut tn: Tensor, contract_path: &ContractionPath) -> Tensor {

--- a/tnc/tests/integration_tests.rs
+++ b/tnc/tests/integration_tests.rs
@@ -29,15 +29,15 @@ fn test_partitioned_contraction_random() {
 
     let r_tn = random_circuit(k, 10, 0.5, 0.5, &mut rng, ConnectivityLayout::Eagle);
     let ref_tn = r_tn.clone();
-    let mut ref_opt = Cotengrust::new(&ref_tn, OptMethod::RandomGreedy(10));
-    let result = ref_opt.find_path();
+    let mut ref_opt = Cotengrust::new(OptMethod::RandomGreedy(10));
+    let result = ref_opt.find_path(&ref_tn);
     let ref_path = result.replace_path();
     let ref_result = contract_tensor_network(ref_tn, &ref_path);
 
     let partitioning = find_partitioning(&r_tn, 12, PartitioningStrategy::MinCut, true);
     let partitioned_tn = partition_tensor_network(r_tn, &partitioning);
-    let mut opt = Cotengrust::new(&partitioned_tn, OptMethod::RandomGreedy(10));
-    let result = opt.find_path();
+    let mut opt = Cotengrust::new(OptMethod::RandomGreedy(10));
+    let result = opt.find_path(&partitioned_tn);
     let path = result.replace_path();
     let result = contract_tensor_network(partitioned_tn, &path);
     assert_abs_diff_eq!(&result, &ref_result);
@@ -50,15 +50,15 @@ fn test_partitioned_contraction() {
 
     let r_tn = random_circuit(k, 10, 0.5, 0.5, &mut rng, ConnectivityLayout::Osprey);
     let ref_tn = r_tn.clone();
-    let mut ref_opt = Cotengrust::new(&ref_tn, OptMethod::Greedy);
-    let result = ref_opt.find_path();
+    let mut ref_opt = Cotengrust::new(OptMethod::Greedy);
+    let result = ref_opt.find_path(&ref_tn);
     let ref_path = result.replace_path();
     let ref_result = contract_tensor_network(ref_tn, &ref_path);
 
     let partitioning = find_partitioning(&r_tn, 12, PartitioningStrategy::MinCut, true);
     let partitioned_tn = partition_tensor_network(r_tn, &partitioning);
-    let mut opt = Cotengrust::new(&partitioned_tn, OptMethod::Greedy);
-    let result = opt.find_path();
+    let mut opt = Cotengrust::new(OptMethod::Greedy);
+    let result = opt.find_path(&partitioned_tn);
     let path = result.replace_path();
     let result = contract_tensor_network(partitioned_tn, &path);
     assert_abs_diff_eq!(&result, &ref_result);
@@ -71,15 +71,15 @@ fn test_partitioned_contraction_mixed() {
 
     let r_tn = random_circuit(k, 10, 0.5, 0.5, &mut rng, ConnectivityLayout::Condor);
     let ref_tn = r_tn.clone();
-    let mut ref_opt = Cotengrust::new(&ref_tn, OptMethod::Greedy);
-    let result = ref_opt.find_path();
+    let mut ref_opt = Cotengrust::new(OptMethod::Greedy);
+    let result = ref_opt.find_path(&ref_tn);
     let ref_path = result.replace_path();
     let ref_result = contract_tensor_network(ref_tn, &ref_path);
 
     let partitioning = find_partitioning(&r_tn, 12, PartitioningStrategy::MinCut, true);
     let partitioned_tn = partition_tensor_network(r_tn, &partitioning);
-    let mut opt = Cotengrust::new(&partitioned_tn, OptMethod::RandomGreedy(15));
-    let result = opt.find_path();
+    let mut opt = Cotengrust::new(OptMethod::RandomGreedy(15));
+    let result = opt.find_path(&partitioned_tn);
     let path = result.replace_path();
     let result = contract_tensor_network(partitioned_tn, &path);
     assert_abs_diff_eq!(&result, &ref_result);
@@ -134,8 +134,8 @@ fn test_partitioned_contraction_need_mpi() {
         let ref_tn = r_tn.clone();
         let partitioning = find_partitioning(&r_tn, size, PartitioningStrategy::MinCut, true);
         let partitioned_tn = partition_tensor_network(r_tn, &partitioning);
-        let mut opt = Cotengrust::new(&partitioned_tn, OptMethod::Greedy);
-        let result = opt.find_path();
+        let mut opt = Cotengrust::new(OptMethod::Greedy);
+        let result = opt.find_path(&partitioned_tn);
         let path = result.replace_path();
         (ref_tn, partitioned_tn, path)
     } else {
@@ -156,8 +156,8 @@ fn test_partitioned_contraction_need_mpi() {
     intermediate_reduce_tensor_network(&mut local_tn, &communication_path, rank, &world, &comm);
 
     if rank == 0 {
-        let mut ref_opt = Cotengrust::new(&ref_tn, OptMethod::RandomGreedy(10));
-        let result = ref_opt.find_path();
+        let mut ref_opt = Cotengrust::new(OptMethod::RandomGreedy(10));
+        let result = ref_opt.find_path(&ref_tn);
         let ref_path = result.replace_path();
 
         let ref_tn = contract_tensor_network(ref_tn, &ref_path);
@@ -186,8 +186,8 @@ fn dj_4qubits_statevector() {
     let circuit = import_qasm(code);
     let (tensor_network, permutator) = circuit.into_statevector_network();
 
-    let mut opt = Cotengrust::new(&tensor_network, OptMethod::Greedy);
-    let result = opt.find_path();
+    let mut opt = Cotengrust::new(OptMethod::Greedy);
+    let result = opt.find_path(&tensor_network);
     let path = result.replace_path();
 
     let final_tensor = contract_tensor_network(tensor_network, &path);
@@ -232,8 +232,8 @@ fn qft_2qubits_expectation() {
     let circuit = import_qasm(code);
     let tensor_network = circuit.into_expectation_value_network();
 
-    let mut opt = Cotengrust::new(&tensor_network, OptMethod::RandomGreedy(3));
-    let result = opt.find_path();
+    let mut opt = Cotengrust::new(OptMethod::RandomGreedy(3));
+    let result = opt.find_path(&tensor_network);
     let path = result.replace_path();
 
     let final_tensor = contract_tensor_network(tensor_network, &path);

--- a/tnc/tests/integration_tests.rs
+++ b/tnc/tests/integration_tests.rs
@@ -10,7 +10,7 @@ use tnc::{
     builders::{connectivity::ConnectivityLayout, random_circuit::random_circuit},
     contractionpath::paths::{
         cotengrust::{Cotengrust, OptMethod},
-        FindPath,
+        ContractionPathResult, Pathfinder,
     },
     io::qasm::import_qasm,
     mpi::communication::{
@@ -30,15 +30,15 @@ fn test_partitioned_contraction_random() {
     let r_tn = random_circuit(k, 10, 0.5, 0.5, &mut rng, ConnectivityLayout::Eagle);
     let ref_tn = r_tn.clone();
     let mut ref_opt = Cotengrust::new(&ref_tn, OptMethod::RandomGreedy(10));
-    ref_opt.find_path();
-    let ref_path = ref_opt.get_best_replace_path();
+    let result = ref_opt.find_path();
+    let ref_path = result.replace_path();
     let ref_result = contract_tensor_network(ref_tn, &ref_path);
 
     let partitioning = find_partitioning(&r_tn, 12, PartitioningStrategy::MinCut, true);
     let partitioned_tn = partition_tensor_network(r_tn, &partitioning);
     let mut opt = Cotengrust::new(&partitioned_tn, OptMethod::RandomGreedy(10));
-    opt.find_path();
-    let path = opt.get_best_replace_path();
+    let result = opt.find_path();
+    let path = result.replace_path();
     let result = contract_tensor_network(partitioned_tn, &path);
     assert_abs_diff_eq!(&result, &ref_result);
 }
@@ -51,15 +51,15 @@ fn test_partitioned_contraction() {
     let r_tn = random_circuit(k, 10, 0.5, 0.5, &mut rng, ConnectivityLayout::Osprey);
     let ref_tn = r_tn.clone();
     let mut ref_opt = Cotengrust::new(&ref_tn, OptMethod::Greedy);
-    ref_opt.find_path();
-    let ref_path = ref_opt.get_best_replace_path();
+    let result = ref_opt.find_path();
+    let ref_path = result.replace_path();
     let ref_result = contract_tensor_network(ref_tn, &ref_path);
 
     let partitioning = find_partitioning(&r_tn, 12, PartitioningStrategy::MinCut, true);
     let partitioned_tn = partition_tensor_network(r_tn, &partitioning);
     let mut opt = Cotengrust::new(&partitioned_tn, OptMethod::Greedy);
-    opt.find_path();
-    let path = opt.get_best_replace_path();
+    let result = opt.find_path();
+    let path = result.replace_path();
     let result = contract_tensor_network(partitioned_tn, &path);
     assert_abs_diff_eq!(&result, &ref_result);
 }
@@ -72,15 +72,15 @@ fn test_partitioned_contraction_mixed() {
     let r_tn = random_circuit(k, 10, 0.5, 0.5, &mut rng, ConnectivityLayout::Condor);
     let ref_tn = r_tn.clone();
     let mut ref_opt = Cotengrust::new(&ref_tn, OptMethod::Greedy);
-    ref_opt.find_path();
-    let ref_path = ref_opt.get_best_replace_path();
+    let result = ref_opt.find_path();
+    let ref_path = result.replace_path();
     let ref_result = contract_tensor_network(ref_tn, &ref_path);
 
     let partitioning = find_partitioning(&r_tn, 12, PartitioningStrategy::MinCut, true);
     let partitioned_tn = partition_tensor_network(r_tn, &partitioning);
     let mut opt = Cotengrust::new(&partitioned_tn, OptMethod::RandomGreedy(15));
-    opt.find_path();
-    let path = opt.get_best_replace_path();
+    let result = opt.find_path();
+    let path = result.replace_path();
     let result = contract_tensor_network(partitioned_tn, &path);
     assert_abs_diff_eq!(&result, &ref_result);
 }
@@ -135,8 +135,8 @@ fn test_partitioned_contraction_need_mpi() {
         let partitioning = find_partitioning(&r_tn, size, PartitioningStrategy::MinCut, true);
         let partitioned_tn = partition_tensor_network(r_tn, &partitioning);
         let mut opt = Cotengrust::new(&partitioned_tn, OptMethod::Greedy);
-        opt.find_path();
-        let path = opt.get_best_replace_path();
+        let result = opt.find_path();
+        let path = result.replace_path();
         (ref_tn, partitioned_tn, path)
     } else {
         Default::default()
@@ -157,8 +157,8 @@ fn test_partitioned_contraction_need_mpi() {
 
     if rank == 0 {
         let mut ref_opt = Cotengrust::new(&ref_tn, OptMethod::RandomGreedy(10));
-        ref_opt.find_path();
-        let ref_path = ref_opt.get_best_replace_path();
+        let result = ref_opt.find_path();
+        let ref_path = result.replace_path();
 
         let ref_tn = contract_tensor_network(ref_tn, &ref_path);
 
@@ -187,8 +187,8 @@ fn dj_4qubits_statevector() {
     let (tensor_network, permutator) = circuit.into_statevector_network();
 
     let mut opt = Cotengrust::new(&tensor_network, OptMethod::Greedy);
-    opt.find_path();
-    let path = opt.get_best_replace_path();
+    let result = opt.find_path();
+    let path = result.replace_path();
 
     let final_tensor = contract_tensor_network(tensor_network, &path);
     let statevector = permutator.apply(final_tensor);
@@ -233,8 +233,8 @@ fn qft_2qubits_expectation() {
     let tensor_network = circuit.into_expectation_value_network();
 
     let mut opt = Cotengrust::new(&tensor_network, OptMethod::RandomGreedy(3));
-    opt.find_path();
-    let path = opt.get_best_replace_path();
+    let result = opt.find_path();
+    let path = result.replace_path();
 
     let final_tensor = contract_tensor_network(tensor_network, &path);
     let data = final_tensor.into_tensor_data().into_data();


### PR DESCRIPTION
The previous `find_path` was unintuitive and had problems. It returned no results, so the results had to be stored in the optimizer. Accessing the results before running `find_path` was possible. And the tensor had to be passed to the optimizer already upon construction. Passing the tensor instead as parameter to `find_path` allows to re-use optimizers with the same settings for different tensors. Returning a result requires `find_path` to actually run and reduces the size of the optimizer structs.