### PR TITLE
Bump kahypar to use bundled Boost

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install system requirements
         run: |
           sudo apt-get update
-          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
+          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
         with:
           submodules: true
@@ -77,7 +77,7 @@ jobs:
       - name: Install system requirements
         run: |
           sudo apt-get update
-          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
+          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
         with:
           submodules: true
@@ -98,7 +98,7 @@ jobs:
       - name: Install system requirements
         run: |
           sudo apt-get update
-          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
+          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
         with:
           submodules: true
@@ -127,7 +127,7 @@ jobs:
       - name: Install system requirements
         run: |
           sudo apt-get update
-          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
+          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
         with:
           submodules: true

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install system requirements
         run: |
           sudo apt-get update
-          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
+          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
         with:
           submodules: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install system requirements
         run: |
           sudo apt-get update
-          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
+          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev
       - name: Install python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # tag=v6.2.0
         with:
@@ -81,7 +81,7 @@ jobs:
       - name: Install system requirements
         run: |
           sudo apt-get update
-          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
+          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev
       - name: Install python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # tag=v6.2.0
         with:
@@ -115,7 +115,6 @@ jobs:
         os: [macos-latest]
     env:
       HDF5_DIR: /opt/homebrew/opt/hdf5
-      BOOST_DIR: /opt/homebrew/opt/boost
       PRTE_MCA_rmaps_default_mapping_policy: ":oversubscribe"
     steps:
       # if your project needs OpenSSL, uncomment this to fix Windows builds.
@@ -126,7 +125,7 @@ jobs:
       #   if: runner.os == 'Windows'
       - name: Install system requirements
         run: |
-          brew install hdf5 openmpi boost
+          brew install hdf5 openmpi
       - name: Install python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # tag=v6.2.0
         with:
@@ -156,7 +155,7 @@ jobs:
       - name: Install system requirements
         run: |
           sudo apt-get update
-          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
+          sudo apt-get install -y libhdf5-dev openmpi-bin libopenmpi-dev
       - name: Install python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # tag=v6.2.0
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,7 +579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "kahypar"
 version = "0.1.0"
-source = "git+https://github.com/Ectras/rust-kahypar#8ab70ce62558d5c419292eea62ffb51a8b3d045d"
+source = "git+https://github.com/Ectras/rust-kahypar#5caa96a318c2e46db2be0552ea5a1d0ae64c080e"
 dependencies = [
  "kahypar-sys",
 ]
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "kahypar-sys"
 version = "0.1.0"
-source = "git+https://github.com/Ectras/rust-kahypar#8ab70ce62558d5c419292eea62ffb51a8b3d045d"
+source = "git+https://github.com/Ectras/rust-kahypar#5caa96a318c2e46db2be0552ea5a1d0ae64c080e"
 dependencies = [
  "bindgen 0.65.1",
  "cmake",
@@ -1676,7 +1676,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,7 +1660,7 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 [[package]]
 name = "rustengra"
 version = "0.1.0"
-source = "git+https://github.com/Ectras/rustengra.git#320d04bdc6d538e123933c5817a20c770e4fbf96"
+source = "git+https://github.com/Ectras/rustengra.git#d0b1239a38963010fe003d7a8233020ad718d8bb"
 dependencies = [
  "pyo3",
  "rustc-hash 2.1.1",

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ cx q[1], q[2];
 The library requires a few dependencies to be installed on the system.
 Those can be installed with
 ```shell
-sudo apt install libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
+sudo apt install libhdf5-dev openmpi-bin libopenmpi-dev
 ```
 Furthermore, for building the library, `cmake` and a C++ compiler must be installed on the system.
 

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -20,7 +20,7 @@ The list of optional features to include is:
 As noted in the README, the library relies on system dependencies.
 To install them, run
 ```bash
-sudo apt install libhdf5-dev openmpi-bin libopenmpi-dev libboost-program-options-dev
+sudo apt install libhdf5-dev openmpi-bin libopenmpi-dev
 ```
 Furthermore, the library relies on C++ libraries that are being built when building the library.
 For this, `cmake` and a C++ compiler are required on the system.

--- a/book/src/running_on_hpc.md
+++ b/book/src/running_on_hpc.md
@@ -20,7 +20,7 @@ This is common in HPC centers.
 ## Running on a cluster
 Usually, HPC clusters use a cluster management system, most commonly SLURM.
 Here, the steps to running this library are similar to:
-1. Load modules for the required dependencies (HDF5, Boost, Python, ...)
+1. Load modules for the required dependencies (HDF5, Python, ...)
 2. Optionally create a virtual Python environment and install the Python dependencies for cotengra
 3. Build the code using `cargo build -r` (assuming the login nodes have the same architecture as the compute nodes)
 4. Write a SLURM script that calls `mpirun` on the compiled binary

--- a/tnc/src/contractionpath/paths/hyperoptimization.rs
+++ b/tnc/src/contractionpath/paths/hyperoptimization.rs
@@ -61,7 +61,7 @@ impl Pathfinder for Hyperoptimizer {
             },
         );
 
-        let ssa_path = cotengra_hyperoptimizer(
+        let (ssa_path, _) = cotengra_hyperoptimizer(
             &inputs,
             outputs.legs(),
             &size_dict,


### PR DESCRIPTION
Using bundled dependencies makes the installation easier and is closer to the Rust idea of just needing to do `cargo add` to use a crate.